### PR TITLE
removed uppercase in ui components

### DIFF
--- a/style/MUI-theme.scss
+++ b/style/MUI-theme.scss
@@ -98,8 +98,6 @@
   --mui-tabs__item--m-current__link--after--BorderWidth: 2px;
   --mui-tabs__link--FontSize: 0.875rem;
 
-  --mui-text-transform: uppercase;
-
   --mui-spacing-4px: calc(0.5 * var(--mui-spacing));
   --mui-spacing-8px: var(--mui-spacing);
   --mui-spacing-12px: calc(1.5 * var(--mui-spacing));
@@ -160,7 +158,6 @@
   --pf-v6-c-button--LineHeight: var(--mui-button--LineHeight);
   --pf-v6-c-button--m-plain--BorderRadius: 50%;
 
-  text-transform: var(--mui-text-transform);
   letter-spacing: 0.02857em;
 }
 
@@ -520,7 +517,6 @@
   --pf-v6-c-menu-toggle--disabled__toggle-icon--Color: var(--mui-palette-action-disabled);
 
   border-radius: var(--mui-shape-borderRadius);
-  text-transform: var(--mui-text-transform);
   font-weight: var(--mui-button-FontWeight);
   letter-spacing: 0.02857em;
 }
@@ -559,7 +555,6 @@
 }
 
 .mui-theme .pf-v6-c-menu-toggle__button {
-  text-transform: var(--mui-text-transform);
   font-weight: var(--mui-button-FontWeight);
   letter-spacing: 0.02857em;
   align-self: stretch;
@@ -805,7 +800,6 @@
 }
 
 .mui-theme .pf-v6-c-tabs__link {
-  text-transform: var(--mui-text-transform);
   font-weight: var(--mui-button-FontWeight);
   line-height: var(--mui-button-line-height);
   letter-spacing: 0.02857em;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Removed the `--mui-text-transform` variable and all of its references such that the referenced components do not turn uppercase (menu, menu items, tabs, and buttons).

<img width="2218" height="675" alt="Screenshot 2025-08-04 at 2 36 13 PM" src="https://github.com/user-attachments/assets/4b94680a-1f8a-4a16-8011-23466826b2cd" />

<img width="2218" height="675" alt="Screenshot 2025-08-04 at 2 25 08 PM" src="https://github.com/user-attachments/assets/2de6e32a-8b58-4053-a750-d4fcfa00d8a3" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Run 'npm link'
2. Go to the desired folder where you want to see changes in and run `npm link mod-arch-shared`
3. Run it and see the changes

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed forced uppercase text styling from buttons, menu toggles, and tab links for a more natural text appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->