### PR TITLE
added optional functions to components to notify parent when editing

### DIFF
--- a/mod-arch-shared/components/EditableLabelsDescriptionListGroup.tsx
+++ b/mod-arch-shared/components/EditableLabelsDescriptionListGroup.tsx
@@ -14,7 +14,6 @@ interface EditableLabelsProps {
   overflowCount?: number; // if isCollapsible is true, this is the number of labels to show before collapsing
   isCollapsible?: boolean;
   onEditingChange?: (editingState: boolean) => void;
-  showAlertWhenEditing?: boolean;
 }
 
 export const EditableLabelsDescriptionListGroup: React.FC<EditableLabelsProps> = ({
@@ -28,7 +27,6 @@ export const EditableLabelsDescriptionListGroup: React.FC<EditableLabelsProps> =
   isCollapsible = true,
   overflowCount,
   onEditingChange,
-  showAlertWhenEditing = false,
 }) => {
   const [isSavingEdits, setIsSavingEdits] = useState(false);
   const [hasSavedEdits, setHasSavedEdits] = useState(false);
@@ -215,7 +213,7 @@ export const EditableLabelsDescriptionListGroup: React.FC<EditableLabelsProps> =
                 tabIndex={-1}
               />
             ))}
-          {showAlertWhenEditing && isEditing && (
+          {onEditingChange && isEditing && (
             <Alert
               data-testid="editing-labels-alert"
               variant={AlertVariant.info}

--- a/mod-arch-shared/components/EditableLabelsDescriptionListGroup.tsx
+++ b/mod-arch-shared/components/EditableLabelsDescriptionListGroup.tsx
@@ -174,6 +174,7 @@ export const EditableLabelsDescriptionListGroup: React.FC<EditableLabelsProps> =
                 </Label>
               ) : undefined
             }
+            className={spacing.mbMd}
           >
             {unsavedLabels.map((label, index) => (
               <Label
@@ -199,7 +200,6 @@ export const EditableLabelsDescriptionListGroup: React.FC<EditableLabelsProps> =
               </Label>
             ))}
           </LabelGroup>
-          <div className={spacing.mtMd} />
           {labelErrors.length > 0 &&
             labelErrors.map((error, index) => (
               <Alert

--- a/mod-arch-shared/components/EditableLabelsDescriptionListGroup.tsx
+++ b/mod-arch-shared/components/EditableLabelsDescriptionListGroup.tsx
@@ -13,6 +13,8 @@ interface EditableLabelsProps {
   labelProps?: LabelProps;
   overflowCount?: number; // if isCollapsible is true, this is the number of labels to show before collapsing
   isCollapsible?: boolean;
+  onEditingChange?: (isEditing: boolean) => void;
+  showAlertWhenEditing?: boolean;
 }
 
 export const EditableLabelsDescriptionListGroup: React.FC<EditableLabelsProps> = ({
@@ -25,11 +27,18 @@ export const EditableLabelsDescriptionListGroup: React.FC<EditableLabelsProps> =
   labelProps = {},
   isCollapsible = true,
   overflowCount,
+  onEditingChange,
+  showAlertWhenEditing = false,
 }) => {
-  const [isEditing, setIsEditing] = useState(false);
   const [isSavingEdits, setIsSavingEdits] = useState(false);
   const [hasSavedEdits, setHasSavedEdits] = useState(false);
   const [unsavedLabels, setUnsavedLabels] = useState(labels);
+  const [isEditing, setIsEditing] = React.useState(false);
+
+  const handleEditingStateChange = (isEditing: boolean) => {
+    setIsEditing(isEditing);
+    onEditingChange?.(isEditing);
+  };
 
   const validateLabels = (): string[] => {
     const errors: string[] = [];
@@ -137,9 +146,6 @@ export const EditableLabelsDescriptionListGroup: React.FC<EditableLabelsProps> =
     return false;
   };
 
-  // Add a ref for the alert
-  const alertRef = React.useRef<HTMLDivElement>(null);
-
   return (
     <DashboardDescriptionListGroup
       editButtonTestId="editable-labels-group-edit"
@@ -193,34 +199,38 @@ export const EditableLabelsDescriptionListGroup: React.FC<EditableLabelsProps> =
               </Label>
             ))}
           </LabelGroup>
-          {labelErrors.length > 0 && (
+          <div className={spacing.mtMd} />
+          {labelErrors.length > 0 &&
+            labelErrors.map((error, index) => (
+              <Alert
+                key={index}
+                data-testid="label-error-alert"
+                variant={AlertVariant.danger}
+                isInline
+                title={error
+                  .split('**')
+                  .map((part, i) => (i % 2 === 0 ? part : <strong key={i}>{part}</strong>))}
+                aria-live="polite"
+                isPlain
+                tabIndex={-1}
+              />
+            ))}
+          {showAlertWhenEditing && isEditing && (
             <Alert
-              ref={alertRef}
-              data-testid="label-error-alert"
-              variant={AlertVariant.danger}
+              data-testid="editing-labels-alert"
+              variant={AlertVariant.info}
               isInline
-              title="Label validation errors:"
+              title="Changes affect all model versions"
               aria-live="polite"
               isPlain
               tabIndex={-1}
-              className={spacing.mtMd}
-            >
-              <ul>
-                {labelErrors.map((error, index) => (
-                  <li key={index}>
-                    {error
-                      .split('**')
-                      .map((part, i) => (i % 2 === 0 ? part : <strong key={i}>{part}</strong>))}
-                  </li>
-                ))}
-              </ul>
-            </Alert>
+            />
           )}
         </>
       }
       onEditClick={() => {
         setUnsavedLabels(labels);
-        setIsEditing(true);
+        handleEditingStateChange(true);
       }}
       onSaveEditsClick={async () => {
         if (labelErrors.length > 0) {
@@ -232,12 +242,12 @@ export const EditableLabelsDescriptionListGroup: React.FC<EditableLabelsProps> =
         } finally {
           setHasSavedEdits(true);
           setIsSavingEdits(false);
-          setIsEditing(false);
+          handleEditingStateChange(false);
         }
       }}
       onDiscardEditsClick={() => {
         setUnsavedLabels(labels);
-        setIsEditing(false);
+        handleEditingStateChange(false);
       }}
     >
       <LabelGroup

--- a/mod-arch-shared/components/EditableLabelsDescriptionListGroup.tsx
+++ b/mod-arch-shared/components/EditableLabelsDescriptionListGroup.tsx
@@ -13,7 +13,7 @@ interface EditableLabelsProps {
   labelProps?: LabelProps;
   overflowCount?: number; // if isCollapsible is true, this is the number of labels to show before collapsing
   isCollapsible?: boolean;
-  onEditingChange?: (isEditing: boolean) => void;
+  onEditingChange?: (editingState: boolean) => void;
   showAlertWhenEditing?: boolean;
 }
 
@@ -35,9 +35,9 @@ export const EditableLabelsDescriptionListGroup: React.FC<EditableLabelsProps> =
   const [unsavedLabels, setUnsavedLabels] = useState(labels);
   const [isEditing, setIsEditing] = React.useState(false);
 
-  const handleEditingStateChange = (isEditing: boolean) => {
-    setIsEditing(isEditing);
-    onEditingChange?.(isEditing);
+  const handleEditingStateChange = (editingState: boolean) => {
+    setIsEditing(editingState);
+    onEditingChange?.(editingState);
   };
 
   const validateLabels = (): string[] => {

--- a/mod-arch-shared/components/EditableTextDescriptionListGroup.tsx
+++ b/mod-arch-shared/components/EditableTextDescriptionListGroup.tsx
@@ -23,7 +23,6 @@ type EditableTextDescriptionListGroupProps = Pick<
   editableVariant: 'TextInput' | 'TextArea';
   truncateMaxLines?: number;
   onEditingChange?: (editingState: boolean) => void;
-  showAlertWhenEditing?: boolean;
 };
 
 const EditableTextDescriptionListGroup: React.FC<EditableTextDescriptionListGroupProps> = ({
@@ -36,7 +35,6 @@ const EditableTextDescriptionListGroup: React.FC<EditableTextDescriptionListGrou
   editableVariant,
   truncateMaxLines = 12,
   onEditingChange,
-  showAlertWhenEditing = false,
 }) => {
   const [isEditing, setIsEditing] = React.useState(false);
   const [unsavedValue, setUnsavedValue] = React.useState(value);
@@ -86,7 +84,7 @@ const EditableTextDescriptionListGroup: React.FC<EditableTextDescriptionListGrou
       contentWhenEditing={
         <>
           <FormFieldset component={editableTextArea} />
-          {showAlertWhenEditing && isEditing && (
+          {onEditingChange && isEditing && (
             <Alert
               data-testid="editing-description-alert"
               className={spacing.mtMd}

--- a/mod-arch-shared/components/EditableTextDescriptionListGroup.tsx
+++ b/mod-arch-shared/components/EditableTextDescriptionListGroup.tsx
@@ -22,7 +22,7 @@ type EditableTextDescriptionListGroupProps = Pick<
   isArchive?: boolean;
   editableVariant: 'TextInput' | 'TextArea';
   truncateMaxLines?: number;
-  onEditingChange?: (isEditing: boolean) => void;
+  onEditingChange?: (editingState: boolean) => void;
   showAlertWhenEditing?: boolean;
 };
 
@@ -43,9 +43,9 @@ const EditableTextDescriptionListGroup: React.FC<EditableTextDescriptionListGrou
   const [isSavingEdits, setIsSavingEdits] = React.useState(false);
   const [isTextExpanded, setIsTextExpanded] = React.useState(false);
 
-  const handleEditingStateChange = (isEditing: boolean) => {
-    setIsEditing(isEditing);
-    onEditingChange?.(isEditing);
+  const handleEditingStateChange = (editingState: boolean) => {
+    setIsEditing(editingState);
+    onEditingChange?.(editingState);
   };
 
   const editableTextArea =

--- a/mod-arch-shared/components/EditableTextDescriptionListGroup.tsx
+++ b/mod-arch-shared/components/EditableTextDescriptionListGroup.tsx
@@ -87,18 +87,16 @@ const EditableTextDescriptionListGroup: React.FC<EditableTextDescriptionListGrou
         <>
           <FormFieldset component={editableTextArea} />
           {showAlertWhenEditing && isEditing && (
-            <>
-              <div className={spacing.mtMd} />
-              <Alert
-                data-testid="editing-description-alert"
-                variant={AlertVariant.info}
-                isInline
-                title="Changes affect all model versions"
-                aria-live="polite"
-                isPlain
-                tabIndex={-1}
-              />
-            </>
+            <Alert
+              data-testid="editing-description-alert"
+              className={spacing.mtMd}
+              variant={AlertVariant.info}
+              isInline
+              title="Changes affect all model versions"
+              aria-live="polite"
+              isPlain
+              tabIndex={-1}
+            />
           )}
         </>
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The core issue is that the parent of the `ModelPropertiesExpandableSection.tsx`, `EditableLabelsDescriptionListGroup.tsx`, and `EditableTextDescriptionListGroup.tsx` has no way of knowing that an edit is being made inside of these components. In our collapsible Model Details Card upstream, we must know this information, so we are going to extract these set states into a context and use them so they can be better shared with the parent component.

New label changes:
<img width="1644" height="786" alt="Screenshot 2025-08-18 at 2 17 41 PM" src="https://github.com/user-attachments/assets/05c0b805-7780-4b7a-b593-7cc5e96b2a1a" />
<img width="855" height="629" alt="Screenshot 2025-08-18 at 2 17 58 PM" src="https://github.com/user-attachments/assets/bd631f35-e4b2-44c6-892e-ac0314a326ee" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. cd into the `mod-arch-shared` folder and run `npm link`
2. Go to Kubeflow model registry and navigate to the `clients/ui/frontend` folder. Then run `npm link mod-arch-shared`
3. For now, in the Model registry repository, make the following changes in this commit (https://github.com/rsun19/model-registry/commit/41eba29e87040fa36eb34450af3d981f5c9290ca). Here, our intention is to test the `showAlert` property for the purposes of the ticket.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

CC @mturley 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional in-context alert shown while editing, indicating that changes affect all model versions.
  * Enhanced editing flows for labels and text with clearer state transitions during edit, save, and discard actions.
  * Improved error display: individual inline alerts are shown per validation error for better clarity.
  * Added spacing and visual refinements around alerts to improve readability during editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->