### PR TITLE
feat: tweak publisch actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
-name: Publish Packages
+name: Manually Publish 
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       package:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request updates the GitHub Actions workflow for publishing packages. The main change is that the workflow can now only be triggered manually, rather than automatically on release events.

Workflow trigger update:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L1-L5): Changed the workflow to be triggered only via `workflow_dispatch` (manual trigger), removing the automatic trigger on release publication.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By manually triggering it in my local fork.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
