### PR TITLE
Add displayName as optional to the Namespace type

### DIFF
--- a/mod-arch-core/types/common.ts
+++ b/mod-arch-core/types/common.ts
@@ -37,6 +37,7 @@ export type KeyValuePair = {
 
 export type Namespace = {
   name: string;
+  displayName?: string;
 };
 
 export type UpdateObjectAtPropAndValue<T> = <K extends keyof T>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Simply add `displayName` to the `Namespace` because it's needed sometimes to show.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for optional display names for namespaces. Interfaces that present namespace information can now show a human-friendly label when available, while continuing to use the technical name as before.
  - Improves clarity in UI lists, selectors, and status messages by displaying friendly names where provided; behavior remains unchanged if no display name is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->