### PR TITLE
chore: bump version to v1.1.3

### DIFF
--- a/mod-arch-core/package-lock.json
+++ b/mod-arch-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-core",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-core",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash-es": "^4.17.15",

--- a/mod-arch-core/package.json
+++ b/mod-arch-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-core",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Core functionality and API utilities for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/mod-arch-kubeflow/package-lock.json
+++ b/mod-arch-kubeflow/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-kubeflow",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-kubeflow",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mui/material": "^6.1.7",

--- a/mod-arch-kubeflow/package.json
+++ b/mod-arch-kubeflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-kubeflow",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Kubeflow-specific theme and UI components for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/mod-arch-shared/package-lock.json
+++ b/mod-arch-shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-shared",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-shared",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.2.0",

--- a/mod-arch-shared/package.json
+++ b/mod-arch-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-shared",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Shared UI components and utilities for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       }
     },
     "mod-arch-core": {
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash-es": "^4.17.15",
@@ -271,7 +271,7 @@
       }
     },
     "mod-arch-kubeflow": {
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mui/material": "^6.1.7",
@@ -1151,7 +1151,7 @@
       }
     },
     "mod-arch-shared": {
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.2.0",


### PR DESCRIPTION
## Version Bump: v1.1.4

This PR bumps the version to v1.1.4.

### Changes since last release

- chore: version bump (43afe5b)
- feat: updated version bump (#45) (99561c6)
- Revert "Nav blocker for when changes unsaved (#37)" (#44) (d1023f1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Incremented version to 1.1.4 across Core, Kubeflow, and Shared modules to align releases.
  - No functional or behavioral changes introduced.
  - Update focuses on version consistency and metadata housekeeping.
  - No user action required; existing workflows and features remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->