### PR TITLE
chore: bump version to v1.1.4

### DIFF
--- a/mod-arch-core/package-lock.json
+++ b/mod-arch-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-core",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-core",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash-es": "^4.17.15",

--- a/mod-arch-core/package.json
+++ b/mod-arch-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-core",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Core functionality and API utilities for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/mod-arch-kubeflow/package-lock.json
+++ b/mod-arch-kubeflow/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-kubeflow",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-kubeflow",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mui/material": "^6.1.7",

--- a/mod-arch-kubeflow/package.json
+++ b/mod-arch-kubeflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-kubeflow",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Kubeflow-specific theme and UI components for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/mod-arch-shared/package-lock.json
+++ b/mod-arch-shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-shared",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-shared",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.2.0",

--- a/mod-arch-shared/package.json
+++ b/mod-arch-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-shared",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Shared UI components and utilities for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-library",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-library",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "workspaces": [
         "mod-arch-core",
@@ -22,7 +22,7 @@
       }
     },
     "mod-arch-core": {
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash-es": "^4.17.15",
@@ -271,7 +271,7 @@
       }
     },
     "mod-arch-kubeflow": {
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mui/material": "^6.1.7",
@@ -1151,7 +1151,7 @@
       }
     },
     "mod-arch-shared": {
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "mod-arch-library",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Modular Architecture Essentials - A monorepo containing libraries for building scalable micro-frontend applications",
   "private": true,
   "workspaces": [
     "mod-arch-core",
-    "mod-arch-shared", 
+    "mod-arch-shared",
     "mod-arch-kubeflow"
   ],
   "engines": {
@@ -25,9 +25,9 @@
     "lint": "npm run test:lint --workspaces --if-present",
     "lint:fix": "npm run test:fix --workspaces --if-present",
     "clean": "rm -rf */dist */node_modules node_modules",
-    "version:patch": "npm version patch --workspaces --no-git-tag-version && npm run version:commit",
-    "version:minor": "npm version minor --workspaces --no-git-tag-version && npm run version:commit",
-    "version:major": "npm version major --workspaces --no-git-tag-version && npm run version:commit",
+    "version:patch": "npm version patch --no-git-tag-version && npm version patch --workspaces --no-git-tag-version && npm run version:commit",
+    "version:minor": "npm version minor --no-git-tag-version && npm version minor --workspaces --no-git-tag-version && npm run version:commit",
+    "version:major": "npm version major --no-git-tag-version && npm version major --workspaces --no-git-tag-version && npm run version:commit",
     "version:commit": "git add -A && git commit -m \"chore: version bump\" --allow-empty",
     "publish:all": "npm run build && npm publish --workspaces",
     "publish:core": "npm run build:core && npm publish --workspace=mod-arch-core",


### PR DESCRIPTION
## Version Bump: v1.1.4

This PR bumps the version to v1.1.4.

### Changes since last release

- chore: version bump (43afe5b)
- feat: updated version bump (#45) (99561c6)
- Revert "Nav blocker for when changes unsaved (#37)" (#44) (d1023f1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Bumped package versions across core, Kubeflow, shared, and root packages.
  * Updated root release/versioning scripts to modify how workspace versioning is executed.
  * No user-facing functionality, API, or behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->