### PR TITLE
chore: bump version to v1.1.5

### DIFF
--- a/mod-arch-core/package-lock.json
+++ b/mod-arch-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-core",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-core",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash-es": "^4.17.15",

--- a/mod-arch-core/package.json
+++ b/mod-arch-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-core",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Core functionality and API utilities for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/mod-arch-kubeflow/package-lock.json
+++ b/mod-arch-kubeflow/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-kubeflow",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-kubeflow",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mui/material": "^6.1.7",

--- a/mod-arch-kubeflow/package.json
+++ b/mod-arch-kubeflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-kubeflow",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Kubeflow-specific theme and UI components for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/mod-arch-shared/package-lock.json
+++ b/mod-arch-shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-shared",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-shared",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.2.0",

--- a/mod-arch-shared/package.json
+++ b/mod-arch-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-shared",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Shared UI components and utilities for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-library",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-library",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "workspaces": [
         "mod-arch-core",
@@ -22,7 +22,7 @@
       }
     },
     "mod-arch-core": {
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash-es": "^4.17.15",
@@ -74,7 +74,7 @@
       }
     },
     "mod-arch-kubeflow": {
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mui/material": "^7.0.0",
@@ -112,7 +112,7 @@
       }
     },
     "mod-arch-shared": {
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-library",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Modular Architecture Essentials - A monorepo containing libraries for building scalable micro-frontend applications",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Version Bump: v1.1.5

This PR bumps the version to v1.1.5.

### Changes since last release

- chore: version bump (e3643d1)
- chore(deps): Bump MUI to v7 (#41) (6365a19)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version from 1.1.4 to 1.1.5 across all modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->