### PR TITLE
chore: bump version to v1.2.0

### DIFF
--- a/mod-arch-core/package-lock.json
+++ b/mod-arch-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-core",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-core",
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash-es": "^4.17.15",

--- a/mod-arch-core/package.json
+++ b/mod-arch-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-core",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Core functionality and API utilities for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/mod-arch-kubeflow/package-lock.json
+++ b/mod-arch-kubeflow/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-kubeflow",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-kubeflow",
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mui/material": "^6.1.7",

--- a/mod-arch-kubeflow/package.json
+++ b/mod-arch-kubeflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-kubeflow",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Kubeflow-specific theme and UI components for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/mod-arch-shared/package-lock.json
+++ b/mod-arch-shared/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-shared",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-shared",
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.2.0",

--- a/mod-arch-shared/package.json
+++ b/mod-arch-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-shared",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Shared UI components and utilities for modular architecture micro-frontend projects",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mod-arch-library",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mod-arch-library",
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "workspaces": [
         "mod-arch-core",
@@ -22,7 +22,7 @@
       }
     },
     "mod-arch-core": {
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash-es": "^4.17.15",
@@ -74,7 +74,7 @@
       }
     },
     "mod-arch-kubeflow": {
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mui/material": "^7.0.0",
@@ -112,7 +112,7 @@
       }
     },
     "mod-arch-shared": {
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/patternfly": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mod-arch-library",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Modular Architecture Essentials - A monorepo containing libraries for building scalable micro-frontend applications",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Version Bump: v1.2.0

This PR bumps the version to v1.2.0.

### Changes since last release

- chore: version bump (cbc613b)
- Notebooks 2.0 Style Fixes (#51) (e20424b)
- Add support for FormData type for rest calls (#55) (6e109f2)
- chore(theming): add PF token SSOT and AI theming guidelines (#50) (5168c8e)
- Changes not saved modal (#52) (2bb6c7f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.2.0 across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->