### PR TITLE
fix: menu toggle styles, support theming for disabled MenuToggle

### DIFF
--- a/mod-arch-shared/package.json
+++ b/mod-arch-shared/package.json
@@ -70,10 +70,10 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@types/showdown": "^2.0.3",
-    "@patternfly/react-core": "^6.2.0",
-    "@patternfly/react-icons": "^6.2.0",
-    "@patternfly/react-styles": "^6.2.0",
-    "@patternfly/react-table": "^6.2.0",
+    "@patternfly/react-core": "^6.4.0",
+    "@patternfly/react-icons": "^6.4.0",
+    "@patternfly/react-styles": "^6.4.0",
+    "@patternfly/react-table": "^6.4.0",
     "core-js": "^3.40.0",
     "expect": "^29.7.0",
     "jest": "^29.7.0",
@@ -88,7 +88,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "@patternfly/patternfly": "^6.2.0",
+    "@patternfly/patternfly": "^6.4.0",
     "classnames": "^2.2.6",
     "dompurify": "^3.2.4",
     "lodash-es": "^4.17.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,7 @@
       "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@patternfly/patternfly": "^6.2.0",
+        "@patternfly/patternfly": "^6.4.0",
         "classnames": "^2.2.6",
         "dompurify": "^3.2.4",
         "lodash-es": "^4.17.15",
@@ -153,10 +153,10 @@
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.21.5",
-        "@patternfly/react-core": "^6.2.0",
-        "@patternfly/react-icons": "^6.2.0",
-        "@patternfly/react-styles": "^6.2.0",
-        "@patternfly/react-table": "^6.2.0",
+        "@patternfly/react-core": "^6.4.0",
+        "@patternfly/react-icons": "^6.4.0",
+        "@patternfly/react-styles": "^6.4.0",
+        "@patternfly/react-table": "^6.4.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.2",
         "@testing-library/react": "^16.1.0",
@@ -3555,21 +3555,21 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.3.1.tgz",
-      "integrity": "sha512-O/lTo5EHKzer/HNzqMQOQEAMG7izDDkEHpAeJ5+sGaeQ/maB3RK7sQsOPS4DjrnMxt4/cC6LogK2mowlbf1j5Q==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.4.0.tgz",
+      "integrity": "sha512-4drFhg74sEc/fftark5wZevODIog17qR4pwLCdB3j5iK3Uu5oMA2SdLhsEeEQggalfnFzve/Km87MdVR0ghhvQ==",
       "license": "MIT"
     },
     "node_modules/@patternfly/react-core": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.3.1.tgz",
-      "integrity": "sha512-1qV20nU4M6PA28qnikH9fPLQlkteaZZToFlATjBNBw7aUI6zIvj7U0akkHz8raWcfHAI+tAzGV7dfKjiv035/g==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.4.0.tgz",
+      "integrity": "sha512-zMgJmcFohp2FqgAoZHg7EXZS7gnaFESquk0qIavemYI0FsqspVlzV2/PUru7w+86+jXfqebRhgubPRsv1eJwEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-icons": "^6.3.1",
-        "@patternfly/react-styles": "^6.3.1",
-        "@patternfly/react-tokens": "^6.3.1",
+        "@patternfly/react-icons": "^6.4.0",
+        "@patternfly/react-styles": "^6.4.0",
+        "@patternfly/react-tokens": "^6.4.0",
         "focus-trap": "7.6.4",
         "react-dropzone": "^14.3.5",
         "tslib": "^2.8.1"
@@ -3580,9 +3580,9 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.3.1.tgz",
-      "integrity": "sha512-uiMounSIww1iZLM4pq+X8c3upzwl9iowXRPjR5CA8entb70lwgAXg3PqvypnuTAcilTq1Y3k5sFTqkhz7rgKcQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.4.0.tgz",
+      "integrity": "sha512-SPjzatm73NUYv/BL6A/cjRA5sFQ15NkiyPAcT8gmklI7HY+ptd6/eg49uBDFmxTQcSwbb5ISW/R6wwCQBY2M+Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3591,23 +3591,23 @@
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.3.1.tgz",
-      "integrity": "sha512-hyb+PlO8YITjKh2wBvjdeZhX6FyB3hlf4r6yG4rPOHk4SgneXHjNSdGwQ3szAxgGqtbENCYtOqwD/8ai72GrxQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.4.0.tgz",
+      "integrity": "sha512-EXmHA67s5sy+Wy/0uxWoUQ52jr9lsH2wV3QcgtvVc5zxpyBX89gShpqv4jfVqaowznHGDoL6fVBBrSe9BYOliQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.3.1.tgz",
-      "integrity": "sha512-ZndBbPcMr/vInP5eELRe9m7MWzRoejRAhWx+25xOdjVAd31/CmMK1nBgZk4QAXaWjH1P+uZaZYsTgr/FMTte2g==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.4.0.tgz",
+      "integrity": "sha512-yv0sFOLGts8a2q9C1xUegjp50ayYyVRe0wKjMf+aMSNIK8sVYu8qu0yfBsCDybsUCldue7+qsYKRLFZosTllWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-core": "^6.3.1",
-        "@patternfly/react-icons": "^6.3.1",
-        "@patternfly/react-styles": "^6.3.1",
-        "@patternfly/react-tokens": "^6.3.1",
+        "@patternfly/react-core": "^6.4.0",
+        "@patternfly/react-icons": "^6.4.0",
+        "@patternfly/react-styles": "^6.4.0",
+        "@patternfly/react-tokens": "^6.4.0",
         "lodash": "^4.17.21",
         "tslib": "^2.8.1"
       },
@@ -3617,9 +3617,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.3.1.tgz",
-      "integrity": "sha512-wt/xKU1tGCDXUueFb+8/Cwxlm4vUD/Xl26O8MxbSLm6NZAHOUPwytJ7gugloGSPvc/zcsXxEgKANL8UZNO6DTw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.4.0.tgz",
+      "integrity": "sha512-iZthBoXSGQ/+PfGTdPFJVulaJZI3rwE+7A/whOXPGp3Jyq3k6X52pr1+5nlO6WHasbZ9FyeZGqXf4fazUZNjbw==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Closes #38 and #65. 

Follow up to https://github.com/kubeflow/notebooks/pull/760#pullrequestreview-3484456733 cc @caponetto 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in https://github.com/kubeflow/notebooks/issues 

Tested in frontend with `npm run start:dev`, navigated to home screen / workspaces list view. 

Before:
<img width="200" height="772" alt="image" src="https://github.com/user-attachments/assets/0f3ecbae-4bc0-4268-b1a2-0d8419b89118" />

After:
<img width="200" height="498" alt="Screenshot 2025-12-04 at 4 31 24 PM" src="https://github.com/user-attachments/assets/da6fe4b5-566b-4e7d-bce4-2f2917cad16a" />

Now matches MUI disabled menu toggle theming, e.g.:
<img width="121" height="61" alt="Screenshot 2025-12-04 at 4 40 46 PM" src="https://github.com/user-attachments/assets/2da54052-93c9-4cab-b3d8-f1236faf4234" />

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PatternFly library dependencies to latest compatible versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->