### PR TITLE
Fix border styles, alignment, and spacing on inputs within modals and table components

### DIFF
--- a/mod-arch-kubeflow/style/MUI-theme.scss
+++ b/mod-arch-kubeflow/style/MUI-theme.scss
@@ -1433,22 +1433,18 @@ left: 0;
 }
 
 /* CSS workaround for spacing in labels in Workspace Kind */
-.form-label-field-group .pf-v6-c-table tr:where(.pf-v6-c-table__tr) > :where(th, td) {
-  padding-block-start: 0px;
-}
-
 /* Special handling for form fields in table cells - remove extra top spacing */
 /* Layout properties (vertical-align, display, overflow) - no PF variables exist */
-.form-label-field-group .pf-v6-c-table tr:where(.pf-v6-c-table__tr) > :where(th, td) {
+.mui-theme .form-label-field-group .pf-v6-c-table tr:where(.pf-v6-c-table__tr) > :where(th, td) {
   /* Layout property - no PF variable exists */
   vertical-align: middle;
   /* Balance padding - use PF component variable for consistency */
-  padding-block-start: var(--pf-v6-c-table--cell--PaddingBlockEnd);
+  --pf-v6-c-table--cell--PaddingBlockStart: 0px;
 }
 
 /* Remove spacing to align form elements at top of table cells */
 /* Margin/padding: No PF variables exist for zero values - using direct CSS */
-.form-label-field-group .pf-v6-c-table tr:where(.pf-v6-c-table__tr) > :where(th, td) .pf-v6-c-form__group {
+.mui-theme .form-label-field-group .pf-v6-c-table tr:where(.pf-v6-c-table__tr) > :where(th, td) .pf-v6-c-form__group {
   /* No PF variables for zero margin/padding - layout constraint */
   margin: 0;
   padding: 0;
@@ -1458,7 +1454,7 @@ left: 0;
   align-self: flex-start;
 }
 
-.form-label-field-group .pf-v6-c-table tr:where(.pf-v6-c-table__tr) > :where(th, td) .pf-v6-c-form__group-control {
+.mui-theme .form-label-field-group .pf-v6-c-table tr:where(.pf-v6-c-table__tr) > :where(th, td) .pf-v6-c-form__group-control {
   /* No PF variables for zero margin/padding - layout constraint */
   margin: 0;
   padding: 0;
@@ -1468,7 +1464,7 @@ left: 0;
   height: auto;
 }
 
-.form-label-field-group .pf-v6-c-table .form-fieldset-wrapper {
+.mui-theme .form-label-field-group .pf-v6-c-table .form-fieldset-wrapper {
   /* No PF variables for zero margin/padding - layout constraint */
   margin: 0;
   padding: 0;
@@ -1483,7 +1479,7 @@ left: 0;
   overflow: visible;
 }
 
-.form-label-field-group .pf-v6-c-table .form-fieldset-wrapper .pf-v6-c-form-control {
+.mui-theme .form-label-field-group .pf-v6-c-table .form-fieldset-wrapper .pf-v6-c-form-control {
   /* No PF variables for zero margin/padding - layout constraint */
   margin: 0;
   padding: 0;
@@ -1499,14 +1495,14 @@ left: 0;
 
 /* Ensure input elements inside table cells can display full text */
 /* Layout/text properties - no PF variables exist */
-.form-label-field-group .pf-v6-c-table .form-fieldset-wrapper input {
+.mui-theme .form-label-field-group .pf-v6-c-table .form-fieldset-wrapper input {
   overflow: visible;
   text-overflow: clip;
   white-space: normal;
   width: 100%;
 }
 
-.form-label-field-group .pf-v6-c-table .form-fieldset-wrapper .form-fieldset {
+.mui-theme .form-label-field-group .pf-v6-c-table .form-fieldset-wrapper .form-fieldset {
   /* Position properties - using PF border width variable */
   top: var(--pf-t--global--border--width--regular);
   /* Layout properties - no PF variables exist */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Closes #84 
Fix issues in NB 2.0 styling where form inputs had incorrect border styles, alignment, and spacing:

Before:

<img width="551" height="288" alt="Screenshot 2026-01-12 at 12 18 43 PM" src="https://github.com/user-attachments/assets/28268787-4ccd-477c-a7ce-317ddc917637" />
<img width="735" height="91" alt="Screenshot 2026-01-12 at 12 21 10 PM" src="https://github.com/user-attachments/assets/f3f12cae-7f01-433c-8260-7ae7d03b1cbb" />
<img width="743" height="300" alt="Screenshot 2026-01-12 at 12 21 56 PM" src="https://github.com/user-attachments/assets/f73d4281-2e70-4c25-86cd-ae71c3fd61d9" />


After:

<img width="625" height="351" alt="Screenshot 2026-01-13 at 2 16 05 PM" src="https://github.com/user-attachments/assets/99c05b47-ee91-4f20-994b-821eaadbf713" />
<img width="811" height="382" alt="Screenshot 2026-01-13 at 2 15 12 PM" src="https://github.com/user-attachments/assets/2d374f0b-bb8c-4ca4-bd69-f15a534bf401" />
<img width="788" height="431" alt="Screenshot 2026-01-13 at 2 15 50 PM" src="https://github.com/user-attachments/assets/99dd5713-aa1a-42eb-baa2-4d473499c2b7" />



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with Notebooks 2.0 and MR set up to point to local mod-arch-library packages in package.json. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved form label behavior and positioning, including special handling for numeric inputs so their labels don’t float
  * Consolidated form-control padding with explicit exclusions for file uploads and pagination
  * Scoped and extended fieldset/form styling to apply consistently inside grids, tables, toolbars and other layout wrappers
  * Reduced table-cell spacing, adjusted borders/padding, and preserved CSS-rendered sort icons for consistent table alignment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->