### PR TITLE
Fix broken navigation for modules installed with mod-arch-installer

### DIFF
--- a/mod-arch-installer/flavors/default/frontend/src/odh/extensions.ts
+++ b/mod-arch-installer/flavors/default/frontend/src/odh/extensions.ts
@@ -35,9 +35,9 @@ const extensions: (NavExtension | RouteExtension | AreaExtension)[] = [
     properties: {
       id: 'mod-arch-view',
       title: 'Modular Architecture',
-      href: 'mod-arch/main-view',
+      href: '/mod-arch/main-view',
       section: 'mod-arch',
-      path: 'mod-arch/main-view/*',
+      path: '/mod-arch/main-view/*',
       label: 'Tech Preview',
     },
   },


### PR DESCRIPTION
## Description

Closes https://github.com/opendatahub-io/mod-arch-library/issues/89

## How Has This Been Tested?

Tested fix on freshly installed module using `npx mod-arch-installer <your-module-name> --flavor default`

Before | After
--- | ---
<video src="https://github.com/user-attachments/assets/6e85e2f0-f2a3-48f6-bcd3-b5eea8413a4e" > | <video src="https://github.com/user-attachments/assets/0d666601-ace0-4c4a-869b-d18a77718a17" >

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated navigation routing configuration to use absolute paths, ensuring consistent navigation behavior across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->