### PR TITLE
Add optional controlled sort and pagination state to Table component

### DIFF
--- a/mod-arch-shared/components/table/Table.tsx
+++ b/mod-arch-shared/components/table/Table.tsx
@@ -31,7 +31,8 @@ const Table = <T,>({
   truncateRenderingAt = 0,
   sortIndex: controlledSortIndex,
   sortDirection: controlledSortDirection,
-  onSortChange,
+  onSortIndexChange,
+  onSortDirectionChange,
   page: controlledPage,
   pageSize: controlledPageSize,
   onPageChange,
@@ -53,8 +54,16 @@ const Table = <T,>({
   const pageSize = controlledPageSize !== undefined ? controlledPageSize : internalPageSize;
 
   const controlledSortProps =
-    controlledSortIndex !== undefined || controlledSortDirection !== undefined || onSortChange
-      ? { sortIndex: controlledSortIndex, sortDirection: controlledSortDirection, onSortChange }
+    controlledSortIndex !== undefined ||
+    controlledSortDirection !== undefined ||
+    onSortIndexChange ||
+    onSortDirectionChange
+      ? {
+          sortIndex: controlledSortIndex,
+          sortDirection: controlledSortDirection,
+          onSortIndexChange,
+          onSortDirectionChange,
+        }
       : undefined;
 
   const sort = useTableColumnSort<T>(

--- a/mod-arch-shared/components/table/useTableColumnSort.ts
+++ b/mod-arch-shared/components/table/useTableColumnSort.ts
@@ -11,7 +11,8 @@ type TableColumnSortProps<DataType> = {
 export type ControlledSortProps = {
   sortIndex?: number | undefined;
   sortDirection?: 'asc' | 'desc' | undefined;
-  onSortChange?: (index: number, direction: 'asc' | 'desc') => void;
+  onSortIndexChange?: (index: number) => void;
+  onSortDirectionChange?: (direction: 'asc' | 'desc') => void;
 };
 
 type TableColumnSortByFieldProps<DataType> = TableColumnSortProps<DataType> & {
@@ -89,7 +90,6 @@ const useTableColumnSort = <T>(
   const [internalSortDirection, setInternalSortDirection] = React.useState<
     'desc' | 'asc' | undefined
   >('asc');
-  const pendingSortIndexRef = React.useRef<number | undefined>(undefined);
 
   // Use controlled props if provided, otherwise use internal state
   const activeSortIndex =
@@ -103,11 +103,15 @@ const useTableColumnSort = <T>(
   const isSortIndexControlled = controlledSortProps?.sortIndex !== undefined;
   const isSortDirectionControlled = controlledSortProps?.sortDirection !== undefined;
 
-  const handleSortChange = (index: number, direction: 'asc' | 'desc'): void => {
-    controlledSortProps?.onSortChange?.(index, direction);
+  const handleSortIndexChange = (index: number): void => {
+    controlledSortProps?.onSortIndexChange?.(index);
     if (!isSortIndexControlled) {
       setInternalSortIndex(index);
     }
+  };
+
+  const handleSortDirectionChange = (direction: 'asc' | 'desc'): void => {
+    controlledSortProps?.onSortDirectionChange?.(direction);
     if (!isSortDirectionControlled) {
       setInternalSortDirection(direction);
     }
@@ -155,17 +159,9 @@ const useTableColumnSort = <T>(
       columns,
       subColumns,
       sortDirection: activeSortDirection,
-      setSortDirection: (dir) => {
-        const nextIndex = pendingSortIndexRef.current ?? activeSortIndex;
-        if (nextIndex !== undefined) {
-          handleSortChange(nextIndex, dir);
-        }
-        pendingSortIndexRef.current = undefined;
-      },
+      setSortDirection: handleSortDirectionChange,
       sortIndex: activeSortIndex,
-      setSortIndex: (index) => {
-        pendingSortIndexRef.current = index;
-      },
+      setSortIndex: handleSortIndexChange,
     }),
   };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds optional controlled props to Table component for sort and pagination state, enabling external control. 

**Changes:**
- Add `sortIndex`, `sortDirection`, `onSortChange` props for controlled sorting
- Add `page`, `pageSize`, `onPageChange`, `onPageSizeChange` props for controlled pagination
- Update `useTableColumnSort` hook to support controlled props
- Maintains backwards compatibility - existing usage continues to work unchanged

This Changes Helps to: 
- Allows external components (e.g., filters) to control table sort/pagination state
- Enables setting default sort order based on external state (e.g., selected Metric & Percentile)
- Fixes issue where default sort order should be controlled by external selections rather than internal component state

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table accepts optional controlled sorting and pagination props so parent components can manage sort and page state.
  * Hybrid mode: uses parent-provided values when present, otherwise falls back to internal state.
  * Stable handlers for page, page-size, and sort updates enable predictable controlled usage.

* **Bug Fixes**
  * Table resets to page 1 when data becomes empty to avoid invalid pages.

* **Behavior**
  * Sorting and pagination behave consistently whether controlled or uncontrolled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->