### PR TITLE
feat: add namespace persistence to selector hook

### DIFF
--- a/mod-arch-core/hooks/README.md
+++ b/mod-arch-core/hooks/README.md
@@ -1,0 +1,118 @@
+# Hooks
+
+This directory contains React hooks for the mod-arch-core library, providing functionality for namespaces, settings, and API state management.
+
+## useNamespaceSelector
+
+A hook for managing namespace selection with optional persistence to browser storage.
+
+### Basic Usage (without persistence)
+
+```typescript
+import { SimpleSelect } from '@patternfly/react-templates';
+import { useNamespaceSelector } from 'mod-arch-core';
+
+const MyComponent = () => {
+  const {
+    namespaces,
+    namespacesLoaded,
+    preferredNamespace,
+    updatePreferredNamespace,
+  } = useNamespaceSelector();
+
+  if (!namespacesLoaded) {
+    return <div>Loading namespaces...</div>;
+  }
+
+  const options = namespaces.map((namespace) => ({
+    content: namespace.name,
+    value: namespace.name,
+    selected: namespace.name === preferredNamespace?.name,
+  }));
+
+  return (
+    <SimpleSelect
+      initialOptions={options}
+      onSelect={(_event, selection) => updatePreferredNamespace({ name: String(selection) })}
+    />
+  );
+};
+```
+
+### With Persistence (storeLastNamespace)
+
+Enable `storeLastNamespace` to persist the selected namespace to browser storage. When enabled:
+- The last used namespace is restored from localStorage on initialization (if valid)
+- The selected namespace is automatically saved to localStorage when it changes
+
+```typescript
+import { useNamespaceSelector } from 'mod-arch-core';
+
+const MyComponent = () => {
+  const {
+    namespaces,
+    preferredNamespace,
+    updatePreferredNamespace,
+  } = useNamespaceSelector({
+    storeLastNamespace: true,
+  });
+
+  // The preferredNamespace will be restored from localStorage
+  // if available and still valid (exists in the namespaces list)
+  // ...
+};
+```
+
+### With Custom Storage Key
+
+You can customize the localStorage key used for persistence:
+
+```typescript
+const { preferredNamespace, updatePreferredNamespace } = useNamespaceSelector({
+  storeLastNamespace: true,
+  storageKey: 'myApp.namespace.lastUsed', // Default: 'mod-arch.namespace.lastUsed'
+});
+```
+
+### Clearing Stored Namespace
+
+When persistence is enabled, you have two ways to clear the stored namespace:
+
+```typescript
+const { updatePreferredNamespace, clearStoredNamespace } = useNamespaceSelector({
+  storeLastNamespace: true,
+});
+
+// Method 1: Pass undefined to updatePreferredNamespace
+updatePreferredNamespace(undefined);
+// • Clears the current namespace selection in the context
+// • Also clears the stored namespace from localStorage
+// • Effectively "resets" both the UI state and the persistence
+
+// Method 2: Use dedicated clear function
+clearStoredNamespace();
+// • Only clears the stored namespace from localStorage
+// • Leaves the current namespace selection in context unchanged
+// • Useful for scenarios like "forget my preference" without changing current state
+```
+
+### API Reference
+
+**Arguments:**
+
+| Property             | Type      | Default                       | Description                                                                                                              |
+|----------------------|-----------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `storeLastNamespace` | `boolean` | `false`                       | When true, persists the last used namespace to browser storage and restores it on initialization if valid.              |
+| `storageKey`         | `string`  | `'mod-arch.namespace.lastUsed'` | Custom storage key for persisting the last used namespace. Only used when `storeLastNamespace` is true.                 |
+
+**Return Value:**
+
+| Property                  | Type                                    | Description                                                                                                                     |
+|---------------------------|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `namespaces`              | `Namespace[]`                           | List of available namespaces                                                                                                    |
+| `namespacesLoaded`        | `boolean`                               | Whether namespaces have finished loading                                                                                        |
+| `namespacesLoadError`     | `Error \| undefined`                    | Error if namespace loading failed                                                                                               |
+| `preferredNamespace`      | `Namespace \| undefined`                | The currently selected namespace                                                                                                |
+| `updatePreferredNamespace` | `(namespace: Namespace \| undefined) => void` | Function to update the selected namespace. When `storeLastNamespace` is enabled, passing `undefined` will clear the stored namespace. |
+| `clearStoredNamespace`    | `() => void`                            | Function to explicitly clear the stored namespace from browser storage. Only effective when `storeLastNamespace` is enabled.   |
+| `initializationError`     | `Error \| undefined`                    | Error during initialization                                                                                                     |

--- a/mod-arch-core/hooks/__tests__/useNamespacePersistence.test.tsx
+++ b/mod-arch-core/hooks/__tests__/useNamespacePersistence.test.tsx
@@ -1,0 +1,463 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { BrowserStorageContextProvider } from '~/context/BrowserStorageContext';
+import { Namespace } from '~/types';
+import { useNamespacePersistence } from '../useNamespacePersistence';
+
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <BrowserStorageContextProvider>{children}</BrowserStorageContextProvider>
+);
+
+const createWrapper = () => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TestWrapper>{children}</TestWrapper>
+  );
+  Wrapper.displayName = 'TestPersistenceHookWrapper';
+  return Wrapper;
+};
+
+describe('useNamespacePersistence', () => {
+  const mockNamespaces: Namespace[] = [
+    { name: 'namespace-a' },
+    { name: 'namespace-b' },
+    { name: 'namespace-c' },
+  ];
+
+  const defaultStorageKey = 'test.namespace.key';
+  const mockContextUpdatePreferredNamespace = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  describe('when storeLastNamespace is false', () => {
+    it('should return the context preferredNamespace directly', () => {
+      const contextPreferredNamespace = { name: 'namespace-b' };
+
+      const { result } = renderHook(
+        () =>
+          useNamespacePersistence({
+            namespaces: mockNamespaces,
+            contextPreferredNamespace,
+            contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+            storeLastNamespace: false,
+            storageKey: defaultStorageKey,
+            namespacesLoaded: true,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      expect(result.current.preferredNamespace).toEqual(contextPreferredNamespace);
+    });
+
+    it('should not persist to storage when updatePreferredNamespace is called', () => {
+      const { result } = renderHook(
+        () =>
+          useNamespacePersistence({
+            namespaces: mockNamespaces,
+            contextPreferredNamespace: { name: 'namespace-a' },
+            contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+            storeLastNamespace: false,
+            storageKey: defaultStorageKey,
+            namespacesLoaded: true,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      act(() => {
+        result.current.updatePreferredNamespace({ name: 'namespace-b' });
+      });
+
+      expect(mockContextUpdatePreferredNamespace).toHaveBeenCalledWith({ name: 'namespace-b' });
+      expect(localStorage.getItem(defaultStorageKey)).toBeNull();
+    });
+  });
+
+  describe('when storeLastNamespace is true', () => {
+    describe('initialization', () => {
+      it('should call context update with valid namespace from storage', async () => {
+        localStorage.setItem(defaultStorageKey, JSON.stringify('namespace-b'));
+
+        renderHook(
+          () =>
+            useNamespacePersistence({
+              namespaces: mockNamespaces,
+              contextPreferredNamespace: { name: 'namespace-a' },
+              contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+              storeLastNamespace: true,
+              storageKey: defaultStorageKey,
+              namespacesLoaded: true,
+            }),
+          { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+          expect(mockContextUpdatePreferredNamespace).toHaveBeenCalledWith({ name: 'namespace-b' });
+        });
+      });
+
+      it('should fallback to context preference when stored namespace is invalid', async () => {
+        localStorage.setItem(defaultStorageKey, JSON.stringify('invalid-namespace'));
+
+        const contextPreferredNamespace = { name: 'namespace-a' };
+        const { result } = renderHook(
+          () =>
+            useNamespacePersistence({
+              namespaces: mockNamespaces,
+              contextPreferredNamespace,
+              contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+              storeLastNamespace: true,
+              storageKey: defaultStorageKey,
+              namespacesLoaded: true,
+            }),
+          { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+          expect(result.current.preferredNamespace).toEqual(contextPreferredNamespace);
+        });
+
+        await waitFor(() => {
+          expect(JSON.parse(localStorage.getItem(defaultStorageKey) || '')).toBe('namespace-a');
+        });
+      });
+
+      it('should sync storage with context preference when no stored namespace', async () => {
+        const contextPreferredNamespace = { name: 'namespace-c' };
+
+        renderHook(
+          () =>
+            useNamespacePersistence({
+              namespaces: mockNamespaces,
+              contextPreferredNamespace,
+              contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+              storeLastNamespace: true,
+              storageKey: defaultStorageKey,
+              namespacesLoaded: true,
+            }),
+          { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+          expect(JSON.parse(localStorage.getItem(defaultStorageKey) || '')).toBe('namespace-c');
+        });
+      });
+
+      it('should not initialize until namespaces are loaded', () => {
+        localStorage.setItem(defaultStorageKey, JSON.stringify('namespace-b'));
+
+        renderHook(
+          () =>
+            useNamespacePersistence({
+              namespaces: mockNamespaces,
+              contextPreferredNamespace: { name: 'namespace-a' },
+              contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+              storeLastNamespace: true,
+              storageKey: defaultStorageKey,
+              namespacesLoaded: false,
+            }),
+          { wrapper: createWrapper() },
+        );
+
+        expect(mockContextUpdatePreferredNamespace).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('persistence during usage', () => {
+      it('should persist to storage when updatePreferredNamespace is called', async () => {
+        const { result } = renderHook(
+          () =>
+            useNamespacePersistence({
+              namespaces: mockNamespaces,
+              contextPreferredNamespace: { name: 'namespace-a' },
+              contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+              storeLastNamespace: true,
+              storageKey: defaultStorageKey,
+              namespacesLoaded: true,
+            }),
+          { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+          expect(localStorage.getItem(defaultStorageKey)).not.toBeNull();
+        });
+
+        act(() => {
+          result.current.updatePreferredNamespace({ name: 'namespace-c' });
+        });
+
+        expect(mockContextUpdatePreferredNamespace).toHaveBeenCalledWith({ name: 'namespace-c' });
+        expect(JSON.parse(localStorage.getItem(defaultStorageKey) || '')).toBe('namespace-c');
+      });
+
+      it('should clear storage when namespace is set to undefined', async () => {
+        localStorage.setItem(defaultStorageKey, JSON.stringify('namespace-b'));
+
+        const { result } = renderHook(
+          () =>
+            useNamespacePersistence({
+              namespaces: mockNamespaces,
+              contextPreferredNamespace: { name: 'namespace-a' },
+              contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+              storeLastNamespace: true,
+              storageKey: defaultStorageKey,
+              namespacesLoaded: true,
+            }),
+          { wrapper: createWrapper() },
+        );
+
+        act(() => {
+          result.current.updatePreferredNamespace(undefined);
+        });
+
+        expect(mockContextUpdatePreferredNamespace).toHaveBeenCalledWith(undefined);
+        await waitFor(() => {
+          expect(JSON.parse(localStorage.getItem(defaultStorageKey) || '')).toBe('');
+        });
+      });
+
+      it('should provide clearStoredNamespace function', async () => {
+        localStorage.setItem(defaultStorageKey, JSON.stringify('namespace-b'));
+
+        const { result } = renderHook(
+          () =>
+            useNamespacePersistence({
+              namespaces: mockNamespaces,
+              contextPreferredNamespace: { name: 'namespace-a' },
+              contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+              storeLastNamespace: true,
+              storageKey: defaultStorageKey,
+              namespacesLoaded: true,
+            }),
+          { wrapper: createWrapper() },
+        );
+
+        expect(typeof result.current.clearStoredNamespace).toBe('function');
+
+        act(() => {
+          result.current.clearStoredNamespace();
+        });
+
+        await waitFor(() => {
+          expect(JSON.parse(localStorage.getItem(defaultStorageKey) || '')).toBe('');
+        });
+        expect(mockContextUpdatePreferredNamespace).not.toHaveBeenCalledWith(undefined);
+      });
+
+      it('should not affect storage when clearStoredNamespace is called with storeLastNamespace false', () => {
+        localStorage.setItem(defaultStorageKey, JSON.stringify('namespace-b'));
+
+        const { result } = renderHook(
+          () =>
+            useNamespacePersistence({
+              namespaces: mockNamespaces,
+              contextPreferredNamespace: { name: 'namespace-a' },
+              contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+              storeLastNamespace: false,
+              storageKey: defaultStorageKey,
+              namespacesLoaded: true,
+            }),
+          { wrapper: createWrapper() },
+        );
+
+        act(() => {
+          result.current.clearStoredNamespace();
+        });
+
+        expect(JSON.parse(localStorage.getItem(defaultStorageKey) || '')).toBe('namespace-b');
+      });
+    });
+
+    describe('storage key customization', () => {
+      it('should use custom storage key', async () => {
+        const customStorageKey = 'myApp.custom.namespace';
+
+        const { result } = renderHook(
+          () =>
+            useNamespacePersistence({
+              namespaces: mockNamespaces,
+              contextPreferredNamespace: { name: 'namespace-a' },
+              contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+              storeLastNamespace: true,
+              storageKey: customStorageKey,
+              namespacesLoaded: true,
+            }),
+          { wrapper: createWrapper() },
+        );
+
+        act(() => {
+          result.current.updatePreferredNamespace({ name: 'namespace-b' });
+        });
+
+        expect(JSON.parse(localStorage.getItem(customStorageKey) || '')).toBe('namespace-b');
+        expect(localStorage.getItem(defaultStorageKey)).toBeNull();
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty namespaces list', () => {
+      const { result } = renderHook(
+        () =>
+          useNamespacePersistence({
+            namespaces: [],
+            contextPreferredNamespace: { name: 'namespace-a' },
+            contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+            storeLastNamespace: true,
+            storageKey: defaultStorageKey,
+            namespacesLoaded: true,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      expect(result.current.preferredNamespace?.name).toBe('namespace-a');
+    });
+
+    it('should handle context with no preferred namespace', async () => {
+      renderHook(
+        () =>
+          useNamespacePersistence({
+            namespaces: mockNamespaces,
+            contextPreferredNamespace: undefined,
+            contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+            storeLastNamespace: true,
+            storageKey: defaultStorageKey,
+            namespacesLoaded: true,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(localStorage.getItem(defaultStorageKey)).toBeNull();
+      });
+    });
+
+    it('should handle rapid namespace changes during initialization', async () => {
+      localStorage.setItem(defaultStorageKey, JSON.stringify('namespace-b'));
+
+      const { rerender } = renderHook(
+        ({ contextPreferredNamespace }) =>
+          useNamespacePersistence({
+            namespaces: mockNamespaces,
+            contextPreferredNamespace,
+            contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+            storeLastNamespace: true,
+            storageKey: defaultStorageKey,
+            namespacesLoaded: true,
+          }),
+        {
+          wrapper: createWrapper(),
+          initialProps: { contextPreferredNamespace: { name: 'namespace-a' } },
+        },
+      );
+
+      await waitFor(() => {
+        expect(mockContextUpdatePreferredNamespace).toHaveBeenCalledWith({ name: 'namespace-b' });
+      });
+
+      rerender({ contextPreferredNamespace: { name: 'namespace-c' } });
+      rerender({ contextPreferredNamespace: { name: 'namespace-a' } });
+      rerender({ contextPreferredNamespace: { name: 'namespace-c' } });
+
+      await waitFor(() => {
+        expect(JSON.parse(localStorage.getItem(defaultStorageKey) || '')).toBe('namespace-c');
+      });
+    });
+
+    it('should handle storage quota exceeded scenarios gracefully', async () => {
+      const originalSetItem = Storage.prototype.setItem;
+      const setItemSpy = jest.fn().mockImplementation(() => {
+        throw new Error('QuotaExceededError: localStorage quota exceeded');
+      });
+      Storage.prototype.setItem = setItemSpy;
+
+      const { result } = renderHook(
+        () =>
+          useNamespacePersistence({
+            namespaces: mockNamespaces,
+            contextPreferredNamespace: { name: 'namespace-a' },
+            contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+            storeLastNamespace: true,
+            storageKey: defaultStorageKey,
+            namespacesLoaded: true,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      expect(() => {
+        act(() => {
+          result.current.updatePreferredNamespace({ name: 'namespace-b' });
+        });
+      }).not.toThrow();
+
+      expect(mockContextUpdatePreferredNamespace).toHaveBeenCalledWith({ name: 'namespace-b' });
+
+      Storage.prototype.setItem = originalSetItem;
+    });
+
+    it('should handle corrupted localStorage data gracefully', async () => {
+      localStorage.setItem(defaultStorageKey, 'invalid-json-{');
+
+      renderHook(
+        () =>
+          useNamespacePersistence({
+            namespaces: mockNamespaces,
+            contextPreferredNamespace: { name: 'namespace-a' },
+            contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+            storeLastNamespace: true,
+            storageKey: defaultStorageKey,
+            namespacesLoaded: true,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        const storedValue = localStorage.getItem(defaultStorageKey);
+        expect(storedValue).not.toBe('invalid-json-{');
+        expect(JSON.parse(storedValue!)).toBe('namespace-a');
+      });
+    });
+
+    it('should handle different storage keys independently', async () => {
+      const storageKey1 = 'test.namespace.instance1';
+      const storageKey2 = 'test.namespace.instance2';
+
+      localStorage.setItem(storageKey1, JSON.stringify('namespace-b'));
+      localStorage.setItem(storageKey2, JSON.stringify('namespace-c'));
+
+      const { result: result1 } = renderHook(
+        () =>
+          useNamespacePersistence({
+            namespaces: mockNamespaces,
+            contextPreferredNamespace: { name: 'namespace-a' },
+            contextUpdatePreferredNamespace: mockContextUpdatePreferredNamespace,
+            storeLastNamespace: true,
+            storageKey: storageKey1,
+            namespacesLoaded: true,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(mockContextUpdatePreferredNamespace).toHaveBeenCalledWith({ name: 'namespace-b' });
+      });
+
+      act(() => {
+        result1.current.updatePreferredNamespace({ name: 'namespace-a' });
+      });
+
+      await waitFor(() => {
+        expect(JSON.parse(localStorage.getItem(storageKey1) || '')).toBe('namespace-a');
+        expect(JSON.parse(localStorage.getItem(storageKey2) || '')).toBe('namespace-c');
+      });
+    });
+  });
+});

--- a/mod-arch-core/hooks/__tests__/useNamespaceSelector.test.tsx
+++ b/mod-arch-core/hooks/__tests__/useNamespaceSelector.test.tsx
@@ -1,0 +1,214 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import * as useFetchStateModule from '~/utilities/useFetchState';
+import { ModularArchContextProvider } from '~/context/ModularArchContext';
+import { BrowserStorageContextProvider } from '~/context/BrowserStorageContext';
+import { DeploymentMode } from '~/utilities';
+import { ModularArchConfig, Namespace } from '~/types';
+import { useNamespaceSelector } from '../useNamespaceSelector';
+
+jest.mock('~/api/k8s', () => ({
+  getNamespaces: jest.fn(() => jest.fn(() => Promise.resolve([]))),
+}));
+
+jest.mock('~/utilities/useFetchState', () => ({
+  useFetchState: jest.fn(),
+}));
+
+const mockUseFetchState = useFetchStateModule.useFetchState as jest.MockedFunction<
+  typeof useFetchStateModule.useFetchState
+>;
+
+const createMockConfig = (
+  mandatoryNamespace?: string,
+  deploymentMode: DeploymentMode = DeploymentMode.Standalone,
+): ModularArchConfig => ({
+  deploymentMode,
+  URL_PREFIX: 'test',
+  BFF_API_VERSION: 'v1',
+  ...(mandatoryNamespace && { mandatoryNamespace }),
+});
+
+const TestWrapper: React.FC<{ config: ModularArchConfig; children: React.ReactNode }> = ({
+  config,
+  children,
+}) => (
+  <BrowserStorageContextProvider>
+    <ModularArchContextProvider config={config}>{children}</ModularArchContextProvider>
+  </BrowserStorageContextProvider>
+);
+
+const createWrapper = (config: ModularArchConfig) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TestWrapper config={config}>{children}</TestWrapper>
+  );
+  Wrapper.displayName = 'TestHookWrapper';
+  return Wrapper;
+};
+
+describe('useNamespaceSelector', () => {
+  const mockNamespaces: Namespace[] = [
+    { name: 'namespace-a' },
+    { name: 'namespace-b' },
+    { name: 'namespace-c' },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+
+    global.fetch = jest.fn().mockResolvedValue({ ok: false });
+
+    mockUseFetchState.mockReturnValue([mockNamespaces, true, undefined, jest.fn()]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  describe('basic functionality (without persistence)', () => {
+    it('should return namespace data from context', () => {
+      const config = createMockConfig();
+      const { result } = renderHook(() => useNamespaceSelector(), {
+        wrapper: createWrapper(config),
+      });
+
+      expect(result.current.namespacesLoaded).toBe(true);
+      expect(result.current.namespaces).toEqual(mockNamespaces);
+      expect(result.current.namespacesLoadError).toBeUndefined();
+      expect(result.current.initializationError).toBeUndefined();
+    });
+
+    it('should return preferredNamespace as first namespace when no mandatory namespace', () => {
+      const config = createMockConfig();
+      const { result } = renderHook(() => useNamespaceSelector(), {
+        wrapper: createWrapper(config),
+      });
+
+      expect(result.current.preferredNamespace?.name).toBe('namespace-a');
+    });
+
+    it('should update preferredNamespace when updatePreferredNamespace is called', () => {
+      const config = createMockConfig();
+      const { result } = renderHook(() => useNamespaceSelector(), {
+        wrapper: createWrapper(config),
+      });
+
+      act(() => {
+        result.current.updatePreferredNamespace({ name: 'namespace-b' });
+      });
+
+      expect(result.current.preferredNamespace?.name).toBe('namespace-b');
+    });
+  });
+
+  describe('with persistence enabled (integration test)', () => {
+    it('should integrate with persistence hook when storeLastNamespace is true', async () => {
+      const defaultStorageKey = 'mod-arch.namespace.lastUsed';
+      localStorage.setItem(defaultStorageKey, JSON.stringify('namespace-b'));
+
+      const config = createMockConfig();
+      const { result } = renderHook(() => useNamespaceSelector({ storeLastNamespace: true }), {
+        wrapper: createWrapper(config),
+      });
+
+      await waitFor(() => {
+        expect(result.current.preferredNamespace?.name).toBe('namespace-b');
+      });
+
+      act(() => {
+        result.current.updatePreferredNamespace({ name: 'namespace-c' });
+      });
+
+      await waitFor(() => {
+        expect(JSON.parse(localStorage.getItem(defaultStorageKey) || '')).toBe('namespace-c');
+      });
+    });
+  });
+
+  describe('with mandatory namespace', () => {
+    it('should return mandatory namespace as preferredNamespace', () => {
+      const mandatoryNs = 'mandatory-namespace';
+      mockUseFetchState.mockReturnValue([[{ name: mandatoryNs }], true, undefined, jest.fn()]);
+
+      const config = createMockConfig(mandatoryNs);
+      const { result } = renderHook(() => useNamespaceSelector(), {
+        wrapper: createWrapper(config),
+      });
+
+      expect(result.current.preferredNamespace?.name).toBe(mandatoryNs);
+    });
+  });
+
+  describe('API contract & backward compatibility', () => {
+    it('should work without any arguments (defaults)', () => {
+      const config = createMockConfig();
+      const { result } = renderHook(() => useNamespaceSelector(), {
+        wrapper: createWrapper(config),
+      });
+
+      expect(result.current.namespacesLoaded).toBe(true);
+      expect(result.current.namespaces).toBeDefined();
+      expect(result.current.preferredNamespace).toBeDefined();
+      expect(typeof result.current.updatePreferredNamespace).toBe('function');
+      expect(typeof result.current.clearStoredNamespace).toBe('function');
+    });
+
+    it('should work with empty object argument', () => {
+      const config = createMockConfig();
+      const { result } = renderHook(() => useNamespaceSelector({}), {
+        wrapper: createWrapper(config),
+      });
+
+      expect(result.current.namespacesLoaded).toBe(true);
+    });
+
+    it('should provide clearStoredNamespace function', async () => {
+      const defaultStorageKey = 'mod-arch.namespace.lastUsed';
+      localStorage.setItem(defaultStorageKey, JSON.stringify('namespace-b'));
+
+      const config = createMockConfig();
+      const { result } = renderHook(() => useNamespaceSelector({ storeLastNamespace: true }), {
+        wrapper: createWrapper(config),
+      });
+
+      act(() => {
+        result.current.clearStoredNamespace();
+      });
+
+      await waitFor(() => {
+        expect(JSON.parse(localStorage.getItem(defaultStorageKey) || '')).toBe('');
+      });
+    });
+  });
+
+  describe('context integration & loading states', () => {
+    it('should handle namespaces not yet loaded', () => {
+      mockUseFetchState.mockReturnValue([[], false, undefined, jest.fn()]);
+
+      const config = createMockConfig();
+      const { result } = renderHook(() => useNamespaceSelector(), {
+        wrapper: createWrapper(config),
+      });
+
+      expect(result.current.namespacesLoaded).toBe(false);
+      expect(result.current.namespaces).toEqual([]);
+    });
+
+    it('should handle namespace loading error', () => {
+      const mockError = new Error('Failed to load namespaces');
+      mockUseFetchState.mockReturnValue([[], true, mockError, jest.fn()]);
+
+      const config = createMockConfig();
+      const { result } = renderHook(() => useNamespaceSelector(), {
+        wrapper: createWrapper(config),
+      });
+
+      expect(result.current.namespacesLoadError).toEqual(mockError);
+    });
+  });
+});

--- a/mod-arch-core/hooks/useNamespacePersistence.ts
+++ b/mod-arch-core/hooks/useNamespacePersistence.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { Namespace } from '~/types';
+import { useBrowserStorage } from '~/context';
+
+export type UseNamespacePersistenceArgs = {
+  namespaces: Namespace[];
+  contextPreferredNamespace: Namespace | undefined;
+  contextUpdatePreferredNamespace: (namespace: Namespace | undefined) => void;
+  storeLastNamespace: boolean;
+  storageKey: string;
+  namespacesLoaded: boolean;
+};
+
+export type UseNamespacePersistenceReturn = {
+  preferredNamespace: Namespace | undefined;
+  updatePreferredNamespace: (namespace: Namespace | undefined) => void;
+  clearStoredNamespace: () => void;
+};
+
+/**
+ * Persist namespace preference with a two-phase flow:
+ * restore once after namespaces load, then track changes.
+ */
+export const useNamespacePersistence = ({
+  namespaces,
+  contextPreferredNamespace,
+  contextUpdatePreferredNamespace,
+  storeLastNamespace,
+  storageKey,
+  namespacesLoaded,
+}: UseNamespacePersistenceArgs): UseNamespacePersistenceReturn => {
+  const [lastUsedNamespace, setLastUsedNamespace] = useBrowserStorage<string>(
+    storageKey,
+    '',
+    true,
+    false,
+  );
+
+  const isInitializedRef = useRef(false);
+  const previousPreferredNamespaceRef = useRef<string | undefined>(undefined);
+
+  const namespaceNames = useMemo(() => namespaces.map((ns) => ns.name), [namespaces]);
+
+  const preferredNamespace = useMemo(() => {
+    if (!storeLastNamespace) {
+      return contextPreferredNamespace;
+    }
+
+    if (lastUsedNamespace && namespaceNames.includes(lastUsedNamespace)) {
+      const matchedNamespace = namespaces.find((namespace) => namespace.name === lastUsedNamespace);
+      if (matchedNamespace) {
+        return matchedNamespace;
+      }
+    }
+
+    return contextPreferredNamespace;
+  }, [
+    storeLastNamespace,
+    contextPreferredNamespace,
+    lastUsedNamespace,
+    namespaceNames,
+    namespaces,
+  ]);
+
+  const updatePreferredNamespace = useCallback(
+    (namespace: Namespace | undefined) => {
+      contextUpdatePreferredNamespace(namespace);
+
+      if (storeLastNamespace) {
+        setLastUsedNamespace(namespace?.name ?? '');
+      }
+    },
+    [contextUpdatePreferredNamespace, storeLastNamespace, setLastUsedNamespace],
+  );
+
+  const clearStoredNamespace = useCallback(() => {
+    if (storeLastNamespace) {
+      setLastUsedNamespace('');
+    }
+  }, [storeLastNamespace, setLastUsedNamespace]);
+
+  // Initialization: restore stored namespace once after load.
+  useEffect(() => {
+    if (!storeLastNamespace || isInitializedRef.current || !namespacesLoaded) {
+      return;
+    }
+
+    isInitializedRef.current = true;
+
+    const storedNamespace =
+      lastUsedNamespace && namespaceNames.includes(lastUsedNamespace)
+        ? namespaces.find((namespace) => namespace.name === lastUsedNamespace)
+        : undefined;
+
+    if (storedNamespace) {
+      previousPreferredNamespaceRef.current = storedNamespace.name;
+      contextUpdatePreferredNamespace(storedNamespace);
+    } else {
+      const fallbackNamespace = contextPreferredNamespace?.name || '';
+      if (fallbackNamespace) {
+        previousPreferredNamespaceRef.current = fallbackNamespace;
+        setLastUsedNamespace(fallbackNamespace);
+      }
+    }
+  }, [
+    storeLastNamespace,
+    namespacesLoaded,
+    lastUsedNamespace,
+    namespaceNames,
+    namespaces,
+    contextPreferredNamespace?.name,
+    contextUpdatePreferredNamespace,
+    setLastUsedNamespace,
+  ]);
+
+  // Persistence: track changes after initialization.
+  useEffect(() => {
+    if (!storeLastNamespace || !isInitializedRef.current) {
+      return;
+    }
+
+    const currentPreferredName = contextPreferredNamespace?.name;
+    const previousPreferredName = previousPreferredNamespaceRef.current;
+
+    if (currentPreferredName !== previousPreferredName && currentPreferredName) {
+      previousPreferredNamespaceRef.current = currentPreferredName;
+      setLastUsedNamespace(currentPreferredName);
+    }
+  }, [storeLastNamespace, contextPreferredNamespace?.name, setLastUsedNamespace]);
+
+  return {
+    preferredNamespace,
+    updatePreferredNamespace,
+    clearStoredNamespace,
+  };
+};

--- a/mod-arch-core/hooks/useNamespaceSelector.ts
+++ b/mod-arch-core/hooks/useNamespaceSelector.ts
@@ -1,22 +1,56 @@
 import { Namespace } from '~/types';
 import { useModularArchContext } from './useModularArchContext';
+import { useNamespacePersistence } from './useNamespacePersistence';
 
-export const useNamespaceSelector = (): {
+const DEFAULT_STORAGE_KEY = 'mod-arch.namespace.lastUsed';
+
+export type UseNamespaceSelectorArgs = {
+  storeLastNamespace?: boolean;
+  storageKey?: string;
+};
+
+export type UseNamespaceSelectorReturn = {
   namespacesLoaded: boolean;
   namespacesLoadError?: Error;
   namespaces: Namespace[];
   preferredNamespace: Namespace | undefined;
   updatePreferredNamespace: (namespace: Namespace | undefined) => void;
+  clearStoredNamespace: () => void;
   initializationError?: Error;
-} => {
+};
+
+export const useNamespaceSelector = (
+  args: UseNamespaceSelectorArgs = {},
+): UseNamespaceSelectorReturn => {
+  const { storeLastNamespace = false, storageKey = DEFAULT_STORAGE_KEY } = args;
   const context = useModularArchContext();
 
+  const {
+    namespacesLoaded,
+    namespacesLoadError,
+    namespaces,
+    preferredNamespace: contextPreferredNamespace,
+    updatePreferredNamespace: contextUpdatePreferredNamespace,
+    initializationError,
+  } = context;
+
+  const { preferredNamespace, updatePreferredNamespace, clearStoredNamespace } =
+    useNamespacePersistence({
+      namespaces,
+      contextPreferredNamespace,
+      contextUpdatePreferredNamespace,
+      storeLastNamespace,
+      storageKey,
+      namespacesLoaded,
+    });
+
   return {
-    namespacesLoaded: context.namespacesLoaded,
-    namespacesLoadError: context.namespacesLoadError,
-    namespaces: context.namespaces,
-    preferredNamespace: context.preferredNamespace,
-    updatePreferredNamespace: context.updatePreferredNamespace,
-    initializationError: context.initializationError,
+    namespacesLoaded,
+    namespacesLoadError,
+    namespaces,
+    preferredNamespace,
+    updatePreferredNamespace,
+    clearStoredNamespace,
+    initializationError,
   };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This pull request introduces a namespace persistence mechanism for the `mod-arch-core` library. The main changes include the addition of a new hook for namespace persistence, enhancements to the `useNamespaceSelector` hook to support persistent storage, comprehensive documentation, and a full test suite to ensure reliability and backward compatibility. 

A similar code has been used in [kubeflow/notebooks](https://github.com/kubeflow/notebooks/tree/notebooks-v2) repository. The goal is to move this code into the shared library so all consumers can reuse and benefit from it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Through [kubeflow/notebooks](https://github.com/kubeflow/notebooks/tree/notebooks-v2) repository (npm link) and unit tests.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Namespace selector can persist the last-used namespace in browser storage and restore it on reload; includes a visible option to clear stored preference.

* **Documentation**
  * Added detailed usage guide covering basic usage, persistence options, custom storage keys, clearing behavior, and examples.

* **Tests**
  * Comprehensive tests added for persistence, initialization, clearing, custom keys, error cases, and concurrent updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->