### PR TITLE
chore: add fetch-tags to release.yml to sync with release tag history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Towards #110 and #113 

According to the result of the dry run in https://github.com/opendatahub-io/mod-arch-library/actions/runs/22181464465/job/64143583928 we need to sync the released version with our [existing release tags](https://github.com/opendatahub-io/mod-arch-library/releases/tag/1.6.0). 

Applied the `fetch-tags` flag here so the dry run should show 1.7.0 as the next release. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We should merge this to verify and then proceed with the follow up #113.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to ensure complete Git tag history is available during deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->