### PR TITLE
fix: input group styles

### DIFF
--- a/mod-arch-kubeflow/style/MUI-theme.scss
+++ b/mod-arch-kubeflow/style/MUI-theme.scss
@@ -1602,6 +1602,11 @@ left: 0;
   --pf-v6-c-table--cell--PaddingBlockStart: 0px;
 }
 
+/* Vertically center action cells (e.g. delete button) in inline edit rows to align with taller MUI form fields */
+.mui-theme .form-label-field-group .pf-v6-c-table tr.pf-v6-c-inline-edit.pf-m-inline-editable > td:last-child {
+  vertical-align: middle;
+}
+
 /* Remove spacing to align form elements at top of table cells */
 /* Margin/padding: No PF variables exist for zero values - using direct CSS */
 .mui-theme .form-label-field-group .pf-v6-c-table tr:where(.pf-v6-c-table__tr) > :where(th, td) .pf-v6-c-form__group {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Needed for https://github.com/kubeflow/notebooks/pull/922

Also closes #97, #99, #112

Fixed input group button styling to vertically align action in MUI form fields within in editable table rows:

<img width="1167" height="482" alt="Screenshot 2026-02-24 at 3 07 37 PM" src="https://github.com/user-attachments/assets/b198c73b-db91-47b0-bf25-5b02f30308e3" />
<img width="1181" height="475" alt="Screenshot 2026-02-24 at 3 07 41 PM" src="https://github.com/user-attachments/assets/8ce4b714-efeb-4aa8-a026-f66404c3db85" />
<img width="1026" height="404" alt="Screenshot 2026-02-24 at 3 07 57 PM" src="https://github.com/user-attachments/assets/aa33a473-361d-4b15-ad7d-c7e3e9cdc393" />

Fixed scroll bar clipping at top and bottom:

Before:
<img width="962" height="377" alt="Screenshot 2026-02-24 at 4 48 35 PM" src="https://github.com/user-attachments/assets/266f7ac0-48f7-42d6-ad93-e9df4b9f7b04" />

After:
<img width="1027" height="437" alt="Screenshot 2026-02-24 at 5 02 12 PM" src="https://github.com/user-attachments/assets/1ca41954-38c6-47e3-9fc7-2721d52578d7" />

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in NB 2.0 UI for https://github.com/kubeflow/notebooks/pull/922

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Modular input-group control styling: introduces consistent compact circular control buttons (e.g., password toggle), unified sizing/spacing tokens, improved icon alignment, clearer hover/focus states, better table cell vertical alignment, and corrected scrollable menu edge spacing.

* **Chores**
  * Release tag format adjusted to remove the leading "v" from version tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->