### PR TITLE
fix: removes id-token: write from the release job’s permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

Follow up to https://github.com/opendatahub-io/mod-arch-library/pull/131

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or tooling changes

## Related Issues

<!-- Link to related Jira tickets or GitHub issues -->
<!-- Example: Resolves: RHOAIENG-12345 -->

## Changes Made

<!-- Detailed list of changes -->

- removes unused `id-token: write` from the release job’s permissions (related to OIDC which was reverted)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes are backwards compatible (or breaking changes are documented)

## Screenshots / Output

<!-- If applicable, add screenshots or command output -->

## Additional Notes

<!-- Any additional context or notes for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted release workflow permissions configuration by removing an unused permission grant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->