### PR TITLE
chore: add OWNERS file for Prow CI onboarding

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,25 @@
+approvers:
+  - lucferbux
+  - christianvogt
+  - andrewballantyne
+  - mturley
+  - Gkrumbach07
+  - emilys314
+  - DaoDaoNoCode
+  - antowaddle
+  - FedeAlonso
+  - Griffin-Sullivan
+  - YuliaKrimerman
+  - manaswinidas
+  - ederign
+  - dgutride
+  - darachcawley
+  - adnankhan666
+  - bobbravo2
+  - jessiehuff
+reviewers:
+  - lucferbux
+  - christianvogt
+  - jenny-s51
+  - liday-rh
+  - rsun19


### PR DESCRIPTION
## Summary

Add OWNERS file to define Prow approvers and reviewers for the upcoming OpenShift CI (Prow) onboarding.

## Type of Change

- [x] CI/CD or tooling changes

## Related Issues

Towards: https://redhat.atlassian.net/browse/RHOAIENG-55745

## Changes Made

- Added root-level `OWNERS` file with approvers (general-approvers + managers-backup-approvers from odh-dashboard) and reviewers (platform team)

## Testing

### How to Test

1. Verify the OWNERS file is valid YAML
2. Confirm the GitHub usernames listed are correct members of the opendatahub-io org

### Test Results

- [x] Lint checks pass (`npm run lint`)
- [x] Build succeeds (`npm run build`)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are backwards compatible (or breaking changes are documented)

## Additional Notes

This OWNERS file is required for the Prow `approve` and `lgtm` plugins to function once mod-arch-library is onboarded to OpenShift CI. The approvers and reviewers lists were confirmed with @lucferbux to match the general approvers list in odh-dashboard: https://github.com/opendatahub-io/odh-dashboard/blob/8329bce5bb911adb32f31b5e4037a06d49e8fa91/OWNERS_ALIASES.

A follow-up PR to openshift/release will configure the CI operator, Prow, and plugin settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review governance configuration to establish approvers and reviewers for managing contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->