### PR TITLE
feat: add review agent skill

### DIFF
--- a/.cursor/skills/review/SKILL.md
+++ b/.cursor/skills/review/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: review
+description: Review code for design token violations, SCSS convention drift, and theme wrapper compliance. Compares source files against pf-tokens-SSOT.json, MUI-default-theme-object.json, and the project's styling rules. Use when the user asks to review code, audit styling, check token usage, or review a PR for convention compliance.
+---
+
+# Design Token & Convention Review
+
+Audit source files against the project's design token SSOT files and styling conventions. Produces a structured report of violations with specific file locations and fixes.
+
+## Inputs
+
+The user may provide:
+
+- **No arguments** — review the main `MUI-theme.scss` and all SCSS/TSX files in the repo.
+- **A file or directory path** — review only those files.
+- **A PR number or branch** — review the diff (changed files only).
+
+## Phase 1: Load reference data
+
+Read these files into context. They are the sources of truth for the review.
+
+1. `mod-arch-kubeflow/style/pf-tokens-SSOT.json` — all valid PF global tokens and component variables.
+2. `mod-arch-kubeflow/style/MUI-default-theme-object.json` — MUI theme values; properties here are auto-available via `--mui-*` CSS variables from ThemeProvider and must NOT be redefined in SCSS.
+3. `mod-arch-kubeflow/.cursor/rules/patternfly-design-tokens.mdc` — token priority rules.
+4. `mod-arch-kubeflow/.cursor/rules/scss-architecture.mdc` — SCSS architecture patterns.
+5. `mod-arch-kubeflow/.cursor/rules/workflow.mdc` — decision tree and form-field wrapper rules.
+6. `mod-arch-kubeflow/AGENTS.md` — form-field wrapper component table and exceptions.
+
+## Phase 2: Determine scope
+
+| User input | Files to review |
+|---|---|
+| No arguments | All `*.scss` and `*.tsx` files under `mod-arch-kubeflow/` and `mod-arch-shared/` |
+| File or directory path | Only the specified path(s) |
+| PR number (`#N`) | Run `git diff main...HEAD -- '*.scss' '*.tsx'` (or `gh pr diff N`) to get changed files and review only those |
+| Branch name | Run `git diff main...<branch> -- '*.scss' '*.tsx'` and review the changed files |
+
+## Phase 3: Run checks
+
+For each file in scope, run the following checks. Use Grep and Read tools to examine the actual source code.
+
+### Check 1: Hardcoded values where tokens exist
+
+Search SCSS files for hardcoded values that should use PF tokens:
+
+- **Colors**: hex values (`#xxx`, `#xxxxxx`), `rgb()`, `rgba()`, named colors used as property values (not inside `var()` or comments). Exception: `rgba(0, 0, 0, X)` patterns used to define custom MUI variables at `:root` scope are acceptable when no MUI auto-available variable exists for that opacity.
+- **Spacing**: bare `px`, `rem`, `em` values used for padding, margin, gap, or spacer properties where a `--pf-t--global--spacer--*` token exists.
+- **Font sizes**: bare values for `font-size` where `--pf-t--global--font--size--*` tokens exist.
+- **Border radius**: bare values where `--pf-t--global--border--radius--*` tokens exist.
+
+For each finding, check `pf-tokens-SSOT.json` to suggest the correct token.
+
+### Check 2: Global tokens set inside component selectors
+
+Search for `--pf-t--global--` being set (not referenced) inside a selector other than `.mui-theme:root`. Global tokens must only be overridden at the `:root` level.
+
+Pattern to flag:
+
+```
+.mui-theme .pf-v6-c-* {
+  --pf-t--global--*: ...;  // VIOLATION
+}
+```
+
+### Check 3: Missing `.mui-theme` scoping
+
+Search for PF component class selectors (`.pf-v6-c-*`) or PF variable overrides (`--pf-v6-c-*`) that are NOT nested inside `.mui-theme`. Every override must be scoped.
+
+### Check 4: Auto-available MUI variables redefined in SCSS
+
+Cross-reference any `--mui-palette-*`, `--mui-typography-*`, `--mui-shape-*`, `--mui-spacing-*`, `--mui-shadows-*` variable definitions in SCSS against `MUI-default-theme-object.json`. If the variable maps to a standard theme property, it should NOT be defined in SCSS — it's already auto-available from `<MUIThemeProvider>`.
+
+### Check 5: Component variables used where global tokens cascade
+
+For each `--pf-v6-c-*` override in SCSS, check `pf-tokens-SSOT.json` to see if that component variable references a global token (`--pf-t--global--*`). If it does, and the global token is already overridden at `:root`, the component-level override may be redundant.
+
+### Check 6: Direct CSS properties where PF variables exist
+
+Search for direct CSS property assignments (e.g., `padding:`, `color:`, `background:`, `border:`, `font-size:`, `font-weight:`, `border-radius:`) in component selectors where PF component variables exist for that property. Cross-reference against `pf-tokens-SSOT.json`.
+
+Exception: `position`, `display`, `flex-direction`, `letter-spacing`, `text-transform`, `overflow`, `visibility`, `z-index` (layout/descriptive properties) are acceptable as direct CSS.
+
+### Check 7: Form-field wrapper compliance (TSX files)
+
+Search TSX files for bordered form input components that should be wrapped:
+
+- `<TextInput` without a parent `<ThemeAwareFormGroupWrapper`
+- `<Select`, `<TypeaheadSelect`, `<MultiTypeaheadSelect` without wrapper
+- `<NumberInput` without wrapper (should use `skipFieldset` prop)
+- `<SearchInput` that should use `<ThemeAwareSearchInput` instead
+- `isMUITheme` conditionals wrapping anything other than `<TextArea` with `autoResize`
+
+### Check 8: Inline styles in TSX with hardcoded values
+
+Search TSX files for `style={{` or `style={` containing hardcoded pixel values, hex colors, or spacing values instead of `var(--pf-t--*)` references.
+
+---
+
+### mod-arch-shared specific checks
+
+The following checks apply only to files under `mod-arch-shared/`.
+
+### Check 9: Shared `vars.scss` using hardcoded hex instead of PF palette tokens
+
+`mod-arch-shared/components/design/vars.scss` defines project-level `--ai-*` color variables. These **must** reference PF palette tokens (`var(--pf-t--color--orange--10)`, etc.) — not hardcoded hex values like `#ffe8cc`. Hardcoded hex breaks dark mode and theme switching because the values don't respond to the active PF theme.
+
+Compare each `--ai-*` variable definition against the equivalent in the downstream `vars.scss` (e.g., odh-dashboard's `frontend/src/concepts/design/vars.scss`) to check for drift. The downstream version is the reference for correct token usage.
+
+### Check 10: Theme-aware component contract integrity
+
+Review the canonical theme-aware wrapper components to verify their contract is maintained:
+
+- **`ThemeAwareFormGroupWrapper.tsx`** must:
+  - Read `isMUITheme` from `useThemeContext()` (not accept it as a prop)
+  - Wrap children in `<FormFieldset>` when `isMUITheme` is true (unless `skipFieldset` is set)
+  - Render `helperTextNode` **outside** `<FormGroup>` when `isMUITheme` is true
+  - Pass through all PF `FormGroup` props
+
+- **`ThemeAwareSearchInput.tsx`** must:
+  - Read `isMUITheme` from `useThemeContext()`
+  - Render `<FormFieldset>` with a `<TextInput>` when `isMUITheme` is true
+  - Render `<SearchInput>` when `isMUITheme` is false
+  - Support `fieldLabel` for the MUI fieldset legend
+
+- **`FormFieldset.tsx`** must:
+  - Render a `<fieldset>` with `aria-hidden="true"` and a `<legend>` matching MUI's `OutlinedInput` structure
+  - Accept any `ReactNode` as `component`
+
+Flag any changes that break these contracts (removed props, changed branching logic, missing `aria-hidden`, etc.).
+
+### Check 11: Shared component SCSS using PF tokens
+
+Search all SCSS files under `mod-arch-shared/` for the same hardcoded value patterns as Check 1, but with shared-specific context:
+
+- Hardcoded colors in component SCSS (e.g., `SimpleSelect.scss`, `MarkdownView.scss`) should use PF semantic tokens or `--ai-*` project variables
+- Hardcoded spacing should use `--pf-t--global--spacer--*` tokens
+- PF component variable overrides should follow the same priority order as kubeflow SCSS (global tokens first)
+
+## Phase 4: Generate report
+
+Produce a structured report with the following format:
+
+```
+## Design Token & Convention Review
+
+### Summary
+- Files reviewed: N
+- Violations found: N
+- By severity: N critical, N warning, N info
+
+### Critical (must fix)
+Violations that will cause visual inconsistency or break theme switching.
+
+### Warning (should fix)
+Violations that reduce maintainability or bypass the token cascade.
+
+### Info (consider)
+Suggestions for improvement that aren't strict violations.
+
+---
+
+For each violation:
+
+**[SEVERITY] Check N: Description**
+- File: `path/to/file.scss`
+- Line: NN
+- Found: `the problematic code`
+- Expected: `the corrected code`
+- Why: Brief explanation referencing the specific rule
+```
+
+### Severity classification
+
+| Severity | Criteria |
+|---|---|
+| Critical | Hardcoded colors/spacing in component selectors; missing `.mui-theme` scope; bare bordered inputs without wrapper; shared `vars.scss` hardcoded hex colors; theme-aware component contract broken |
+| Warning | Redundant component variable overrides; global tokens in component selectors; auto-available MUI vars redefined; shared component SCSS hardcoded values |
+| Info | Direct CSS where a PF variable probably exists but isn't in the SSOT file; minor style improvements |
+
+## Phase 5: Suggest fixes
+
+For each critical and warning violation, provide the exact replacement code. For example:
+
+```
+Found:  padding: 16px;
+Fix:    --pf-v6-c-card--PaddingBlockStart: var(--pf-t--global--spacer--md);
+```
+
+If there are no violations, confirm the files pass review and note any particularly well-structured patterns worth preserving.

--- a/.cursor/skills/review/SKILL.md
+++ b/.cursor/skills/review/SKILL.md
@@ -32,7 +32,7 @@ Read these files into context. They are the sources of truth for the review.
 |---|---|
 | No arguments | All `*.scss` and `*.tsx` files under `mod-arch-kubeflow/` and `mod-arch-shared/` |
 | File or directory path | Only the specified path(s) |
-| PR number (`#N`) | Run `git diff main...HEAD -- '*.scss' '*.tsx'` (or `gh pr diff N`) to get changed files and review only those |
+| PR number (`#N`) | Run `gh pr diff N` to get changed files and review only those matching `*.scss` or `*.tsx` |
 | Branch name | Validate the branch ref matches `^[A-Za-z0-9._/][A-Za-z0-9._/-]*$` (anchored, no leading hyphens, no whitespace or shell metacharacters), then resolve it with `git rev-parse --verify <branch>` before use; if it resolves cleanly, run `git diff "main...<branch>" -- '*.scss' '*.tsx'` using the validated ref and review the changed files |
 
 ## Phase 3: Run checks
@@ -100,13 +100,7 @@ Search TSX files for `style={{` or `style={` containing hardcoded pixel values, 
 
 The following checks apply only to files under `mod-arch-shared/`.
 
-### Check 9: Shared `vars.scss` using hardcoded hex instead of PF palette tokens
-
-`mod-arch-shared/components/design/vars.scss` defines project-level `--ai-*` color variables. These **must** reference PF palette tokens (`var(--pf-t--color--orange--10)`, etc.) — not hardcoded hex values like `#ffe8cc`. Hardcoded hex breaks dark mode and theme switching because the values don't respond to the active PF theme.
-
-Compare each `--ai-*` variable definition against the equivalent in the downstream `vars.scss` (e.g., odh-dashboard's `frontend/src/concepts/design/vars.scss`) to check for drift. The downstream version is the reference for correct token usage.
-
-### Check 10: Theme-aware component contract integrity
+### Check 9: Theme-aware component contract integrity
 
 Review the canonical theme-aware wrapper components to verify their contract is maintained:
 
@@ -128,7 +122,7 @@ Review the canonical theme-aware wrapper components to verify their contract is 
 
 Flag any changes that break these contracts (removed props, changed branching logic, missing `aria-hidden`, etc.).
 
-### Check 11: Shared component SCSS using PF tokens
+### Check 10: Shared component SCSS using PF tokens
 
 Search all SCSS files under `mod-arch-shared/` for the same hardcoded value patterns as Check 1, but with shared-specific context:
 
@@ -173,7 +167,7 @@ For each violation:
 
 | Severity | Criteria |
 |---|---|
-| Critical | Hardcoded colors/spacing in component selectors; missing `.mui-theme` scope; bare bordered inputs without wrapper; shared `vars.scss` hardcoded hex colors; theme-aware component contract broken |
+| Critical | Hardcoded colors/spacing in component selectors; missing `.mui-theme` scope; bare bordered inputs without wrapper; theme-aware component contract broken |
 | Warning | Redundant component variable overrides; global tokens in component selectors; auto-available MUI vars redefined; shared component SCSS hardcoded values |
 | Info | Direct CSS where a PF variable probably exists but isn't in the SSOT file; minor style improvements |
 

--- a/.cursor/skills/review/SKILL.md
+++ b/.cursor/skills/review/SKILL.md
@@ -88,7 +88,7 @@ Search TSX files for bordered form input components that should be wrapped:
 - `<Select`, `<TypeaheadSelect`, `<MultiTypeaheadSelect` without wrapper
 - `<NumberInput` without wrapper (should use `skipFieldset` prop)
 - `<SearchInput` that should use `<ThemeAwareSearchInput` instead
-- `isMUITheme` conditionals wrapping anything other than `<TextArea` with `autoResize`
+- Ad-hoc inline `isMUITheme` conditionals (e.g., `{isMUITheme ? <A /> : <B />}`) used directly in consumer components to branch rendering for anything other than `<TextArea` with `autoResize`. Named wrapper components like `ThemeAwareFormGroupWrapper` and `ThemeAwareSearchInput` that encapsulate `isMUITheme` logic internally are exempt — those are the intended pattern
 
 ### Check 8: Inline styles in TSX with hardcoded values
 

--- a/.cursor/skills/review/SKILL.md
+++ b/.cursor/skills/review/SKILL.md
@@ -11,7 +11,7 @@ Audit source files against the project's design token SSOT files and styling con
 
 The user may provide:
 
-- **No arguments** — review the main `MUI-theme.scss` and all SCSS/TSX files in the repo.
+- **No arguments** — review all SCSS and TSX files under `mod-arch-kubeflow/` and `mod-arch-shared/`.
 - **A file or directory path** — review only those files.
 - **A PR number or branch** — review the diff (changed files only).
 
@@ -33,7 +33,7 @@ Read these files into context. They are the sources of truth for the review.
 | No arguments | All `*.scss` and `*.tsx` files under `mod-arch-kubeflow/` and `mod-arch-shared/` |
 | File or directory path | Only the specified path(s) |
 | PR number (`#N`) | Run `git diff main...HEAD -- '*.scss' '*.tsx'` (or `gh pr diff N`) to get changed files and review only those |
-| Branch name | Run `git diff main...<branch> -- '*.scss' '*.tsx'` and review the changed files |
+| Branch name | Validate the branch ref matches `^[A-Za-z0-9._/][A-Za-z0-9._/-]*$` (anchored, no leading hyphens, no whitespace or shell metacharacters), then resolve it with `git rev-parse --verify <branch>` before use; if it resolves cleanly, run `git diff "main...<branch>" -- '*.scss' '*.tsx'` using the validated ref and review the changed files |
 
 ## Phase 3: Run checks
 
@@ -56,7 +56,7 @@ Search for `--pf-t--global--` being set (not referenced) inside a selector other
 
 Pattern to flag:
 
-```
+```scss
 .mui-theme .pf-v6-c-* {
   --pf-t--global--*: ...;  // VIOLATION
 }
@@ -140,7 +140,7 @@ Search all SCSS files under `mod-arch-shared/` for the same hardcoded value patt
 
 Produce a structured report with the following format:
 
-```
+```md
 ## Design Token & Convention Review
 
 ### Summary
@@ -181,7 +181,7 @@ For each violation:
 
 For each critical and warning violation, provide the exact replacement code. For example:
 
-```
+```text
 Found:  padding: 16px;
 Fix:    --pf-v6-c-card--PaddingBlockStart: var(--pf-t--global--spacer--md);
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,18 @@ npm run lint:fix          # Fix linting issues
 
 ---
 
+## Agent Skills
+
+Skills provide multi-step workflows. They live in `.cursor/skills/`. Read the relevant skill file
+before starting the task.
+
+| Skill | Directory | Use when |
+| ------------------- | -------------------------------- | ------------------------------------------------------------------- |
+| **Release Version** | `skills/release-version/` | Preparing a release, bumping version, or creating a release PR |
+| **Review** | `skills/review/` | Reviewing code for design token violations, SCSS convention drift, or theme wrapper compliance |
+
+---
+
 ## Package-Specific Guidelines
 
 Each package may have its own AGENTS.md with package-specific guidance:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,8 +141,8 @@ before starting the task.
 
 | Skill | Directory | Use when |
 | ------------------- | -------------------------------- | ------------------------------------------------------------------- |
-| **Release Version** | `skills/release-version/` | Preparing a release, bumping version, or creating a release PR |
-| **Review** | `skills/review/` | Reviewing code for design token violations, SCSS convention drift, or theme wrapper compliance |
+| **Release Version** | `.cursor/skills/release-version/` | Preparing a release, bumping version, or creating a release PR |
+| **Review** | `.cursor/skills/review/` | Reviewing code for design token violations, SCSS convention drift, or theme wrapper compliance |
 
 ---
 


### PR DESCRIPTION
## Summary

Add a review agent skill that audits SCSS and TSX files against the project's design token files and styling rules to catch convention drift.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or tooling changes

## Related Issues

Towards https://redhat.atlassian.net/browse/RHOAIENG-52366

## Changes Made

- Added `.cursor/skills/review/SKILL.md`:
  - Loads `pf-tokens-SSOT.json` and `MUI-default-theme-object.json` as reference data
  - Runs 11 checks: hardcoded values, global token misplacement, missing `.mui-theme` scoping, redundant MUI variable definitions, cascading token waste, direct CSS violations, form-field wrapper compliance, inline style auditing, shared `vars.scss` hex drift, theme-aware component contract integrity, and shared component SCSS compliance
  - Produces a structured report with severity levels (critical/warning/info) and exact fix suggestions
- Updated `AGENTS.md` — added an Agent Skills table documenting both the existing `release-version` and the new `review` skill for discoverability

## Testing

### How to Test

1. `/review` with no arguments — verify it scans all `*.scss` and `*.tsx` files under both `mod-arch-kubeflow/` and `mod-arch-shared/`
2. `/review mod-arch-kubeflow/style/MUI-theme.scss` — verify it scopes to just that file
3. `/review mod-arch-shared/` — verify it scopes to the shared package and runs checks 9-11
4. `/review #N` (with a PR number) — verify it only reviews changed files from the PR diff
5. Verify the agent:
   - Loads `pf-tokens-SSOT.json` and `MUI-default-theme-object.json` as reference data
   - Produces a structured report with severity levels (critical/warning/info)
   - Includes file path, line number, the problematic code, and an exact fix for each violation
7. Confirm the skill appears in the Agent Skills table in `AGENTS.md`

### Test Results

- [ ] Unit tests pass (`npm test`)
- [ ] Lint checks pass (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [x] Manual testing completed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes are backwards compatible (or breaking changes are documented)

## Screenshots / Output

N/A — this is an agent skill (markdown), not a UI change.

## Additional Notes

- The skill cross-references code against the same files that the existing Cursor rules (`patternfly-design-tokens.mdc`, `scss-architecture.mdc`, `workflow.mdc`) describe. The difference is that rules guide the agent while *writing* code, while this skill lets the agent *audit* existing code or PRs on demand.
- Companion review skill will be created for odh-dashboard in a separate follow-up PR — it covers the consumer-side conventions (PF v6 compliance, semantic token usage, custom class naming, PF wrapper components).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design-token and SCSS/TSX convention review workflow that can run across the repo, on specific paths, or against PRs/branches; enforces theme-wrapper and token-override rules, detects hardcoded values, and emits structured findings (Critical/Warning/Info) with exact replacement suggestions.
  * Updated agent guidance to document available agent "skills," including the new review skill for token and convention audits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->