### PR TITLE
fix: enforce sequential workspace build order

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "npm": ">=10.0.0"
   },
   "scripts": {
-    "build": "npm run build --workspaces",
+    "build": "npm run build:core && npm run build:kubeflow && npm run build:shared && npm run build:installer",
     "build:core": "npm run build --workspace=mod-arch-core",
     "build:shared": "npm run build --workspace=mod-arch-shared",
     "build:kubeflow": "npm run build --workspace=mod-arch-kubeflow",


### PR DESCRIPTION
## Summary

- Unblocks https://github.com/openshift/release/pull/77105
- Enforce sequential build order to fix clean-environment build failures

## Problem

`npm run build --workspaces` does not guarantee execution order. In a clean environment (no cached `dist/`), `mod-arch-shared` and `mod-arch-kubeflow` fail because `mod-arch-core`'s `dist/` doesn't exist yet. TypeScript follows workspace symlinks to source files where `~/*` path aliases resolve against the wrong root.

Discovered during Prow CI onboarding rehearsal jobs.

## Links

- Closes #186
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-56378

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Root build now runs a fixed, ordered sequence of workspace builds (core, kubeflow, shared, installer), making builds deterministic and predictable. The root build no longer implicitly iterates over all workspaces—ensure any additional workspace builds are added explicitly. This change improves build order control and repeatability in CI/local runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->