### PR TITLE
fix: replace prepare with prepublishOnly and reorder workspaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,14 +50,14 @@ jobs:
     - name: Install dependencies
       run: npm ci
       
+    - name: Build all packages
+      run: npm run build
+
     - name: Run linting
       run: npm run lint
       
     - name: Run all tests
       run: npm run test
-      
-    - name: Build all packages
-      run: npm run build
 
   test-coverage:
     name: Test Coverage
@@ -102,7 +102,10 @@ jobs:
         
     - name: Install dependencies
       run: npm ci
-      
+
+    - name: Build all packages
+      run: npm run build
+
     - name: Test ${{ matrix.package }}
       run: |
         if [ "${{ matrix.package }}" = "mod-arch-core" ]; then
@@ -111,14 +114,4 @@ jobs:
           npm run test:shared
         elif [ "${{ matrix.package }}" = "mod-arch-kubeflow" ]; then
           npm run test:kubeflow
-        fi
-        
-    - name: Build ${{ matrix.package }}
-      run: |
-        if [ "${{ matrix.package }}" = "mod-arch-core" ]; then
-          npm run build:core
-        elif [ "${{ matrix.package }}" = "mod-arch-shared" ]; then
-          npm run build:shared
-        elif [ "${{ matrix.package }}" = "mod-arch-kubeflow" ]; then
-          npm run build:kubeflow
         fi

--- a/mod-arch-core/package.json
+++ b/mod-arch-core/package.json
@@ -25,8 +25,7 @@
     "test:type-check": "tsc --noEmit",
     "test:fix": "eslint --ext .js,.ts,.jsx,.tsx . --fix",
     "test:lint": "eslint --max-warnings 0 --ext .js,.ts,.jsx,.tsx .",
-    "prepare": "npm run build",
-    "prepublishOnly": "npm run test"
+    "prepublishOnly": "npm run build && npm run test"
   },
   "repository": {
     "type": "git",

--- a/mod-arch-kubeflow/package.json
+++ b/mod-arch-kubeflow/package.json
@@ -28,7 +28,7 @@
     "test:type-check": "tsc --noEmit",
     "test:fix": "eslint --ext .js,.ts,.jsx,.tsx . --fix",
     "test:lint": "eslint --max-warnings 0 --ext .js,.ts,.jsx,.tsx .",
-    "prepare": "npm run build"
+    "prepublishOnly": "npm run build && npm run test"
   },
   "repository": {
     "type": "git",

--- a/mod-arch-shared/package.json
+++ b/mod-arch-shared/package.json
@@ -26,8 +26,7 @@
     "test:type-check": "tsc --noEmit",
     "test:fix": "eslint --ext .js,.ts,.jsx,.tsx . --fix",
     "test:lint": "eslint --max-warnings 0 --ext .js,.ts,.jsx,.tsx .",
-    "prepare": "npm run build",
-    "prepublishOnly": "npm run test"
+    "prepublishOnly": "npm run build && npm run test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "workspaces": [
     "mod-arch-core",
-    "mod-arch-shared",
     "mod-arch-kubeflow",
+    "mod-arch-shared",
     "mod-arch-installer"
   ],
   "engines": {


### PR DESCRIPTION
## Summary
- Follow-up to #187 
- Replace `"prepare": "npm run build"` with `"prepublishOnly"` in `mod-arch-core`, `mod-arch-shared`, and `mod-arch-kubeflow` package.json files
- Reorder `workspaces` array in root `package.json` to match the dependency graph: `core → kubeflow → shared → installer`

## Problem
`npm ci` triggers `prepare` lifecycle scripts for each workspace during installation. Because `mod-arch-shared` was declared before `mod-arch-kubeflow` in the workspaces array, shared's TypeScript compilation ran before kubeflow was built. TypeScript followed workspace symlinks into kubeflow's raw source files, encountered unresolvable `~/*` path aliases, and caused `npm ci` to exit with code 2—which also cleans up bin links, breaking all downstream commands.

This blocks the OpenShift CI onboarding PR ([openshift/release#77105](https://github.com/openshift/release/pull/77105)).

## Fix
- **`prepublishOnly` instead of `prepare`**: The build step only needs to run before `npm publish`, not on every `npm install`/`npm ci`. This prevents the cascading failure during dependency installation.
- **Workspace reorder**: Aligns the declaration order with the build dependency graph as an additional safety measure.

## Verification
Tested the full CI flow (`npm ci && npm run build && npm run lint && npm run test`) in a clean UBI9/nodejs-22 container—all commands pass with exit code 0.

Follows #186
Related: [RHOAIENG-56378](https://redhat.atlassian.net/browse/RHOAIENG-56378)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Publishing now runs a build followed by tests to ensure packages are built before publication.
  * CI/test workflow updated to perform a full monorepo build before linting and running tests for greater consistency.
  * Monorepo workspace ordering adjusted for internal package resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->