### PR TITLE
fix: run build before test in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm run test
-
       - name: Build packages
         run: npm run build
+
+      - name: Run tests
+        run: npm run test
 
       - name: Semantic Release
         run: npx semantic-release


### PR DESCRIPTION
## Summary
- Fixes [semantic release step](https://github.com/opendatahub-io/mod-arch-library/actions/runs/23949259043/job/69852514861) which failed on commit (since semantic release step is not part of PR checks) 
- Swap build and test step order in `release.yml` so `npm run build` runs before `npm run test`

## Problem
PR #193 removed workspace `prepare` scripts, so `npm ci` no longer builds packages during install. The release workflow ran `npm run test` before `npm run build`, causing `test:type-check` (`tsc --noEmit`) in `mod-arch-shared` to fail — TypeScript follows workspace symlinks into unbuilt source files with unresolvable `~/*` path aliases.

## Fix
Move `npm run build` before `npm run test`, matching the order already used in `test.yml`.

Made with [Cursor](https://cursor.com)