### PR TITLE
feat(mod-arch-shared): export ai-u-spin utility and align design vars

### DIFF
--- a/mod-arch-shared/components/design/utilities.scss
+++ b/mod-arch-shared/components/design/utilities.scss
@@ -1,0 +1,4 @@
+// Shared dashboard utility classes (consumed by host and federated MF remotes).
+.odh-u-spin {
+  animation: pf-v6-c-spinner-animation-rotate 3s linear infinite;
+}

--- a/mod-arch-shared/components/design/utilities.scss
+++ b/mod-arch-shared/components/design/utilities.scss
@@ -1,4 +1,4 @@
-// Shared dashboard utility classes (consumed by host and federated MF remotes).
-.odh-u-spin {
+// Shared utility classes (consumed by host and federated MF remotes).
+.ai-u-spin {
   animation: pf-v6-c-spinner-animation-rotate 3s linear infinite;
 }

--- a/mod-arch-shared/components/design/utilities.scss
+++ b/mod-arch-shared/components/design/utilities.scss
@@ -1,4 +1,17 @@
 // Shared dashboard utility classes (consumed by host and federated MF remotes).
+
+// Local fallback so the rotation works without importing PatternFly v6 spinner CSS.
+// If your app already includes @patternfly/patternfly/components/Spinner/spinner.css
+// (or the full patternfly.css bundle), this is a harmless duplicate.
+@keyframes pf-v6-c-spinner-animation-rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 .odh-u-spin {
   animation: pf-v6-c-spinner-animation-rotate 3s linear infinite;
 }

--- a/mod-arch-shared/components/design/utilities.scss
+++ b/mod-arch-shared/components/design/utilities.scss
@@ -1,17 +1,4 @@
 // Shared dashboard utility classes (consumed by host and federated MF remotes).
-
-// Local fallback so the rotation works without importing PatternFly v6 spinner CSS.
-// If your app already includes @patternfly/patternfly/components/Spinner/spinner.css
-// (or the full patternfly.css bundle), this is a harmless duplicate.
-@keyframes pf-v6-c-spinner-animation-rotate {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
 .odh-u-spin {
   animation: pf-v6-c-spinner-animation-rotate 3s linear infinite;
 }

--- a/mod-arch-shared/components/design/vars.scss
+++ b/mod-arch-shared/components/design/vars.scss
@@ -38,7 +38,7 @@
   --ai-general--LabelBackgroundColor: var(--pf-t--color--gray--20);
   --ai-general--BorderColor: var(--pf-t--color--gray--30);
   --ai-general--SelectedColor: var(--pf-t--color--gray--40);
-  --ai-general--Color:var(--pf-t--color--gray--50);
+  --ai-general--Color: var(--pf-t--color--gray--50);
   --ai-general--IconColor: var(--pf-t--global--text--color--regular);
 
   --ai-project--BackgroundColor: var(--ai-organize--BackgroundColor);

--- a/mod-arch-shared/components/design/vars.scss
+++ b/mod-arch-shared/components/design/vars.scss
@@ -42,70 +42,70 @@
   --ai-general--IconColor: var(--pf-t--global--text--color--regular);
 
   --ai-project--BackgroundColor: var(--ai-organize--BackgroundColor);
-  --ai-project--LabelBackgroundColor: var(--ai-organize-LabelBackgroundColor);
+  --ai-project--LabelBackgroundColor: var(--ai-organize--LabelBackgroundColor);
   --ai-project--BorderColor: var(--ai-organize--BorderColor);
   --ai-project--SelectedColor: var(--ai-organize--SelectedColor);
   --ai-project--Color: var(--ai-organize--BorderColor);
   --ai-project--IconColor: var(--ai-organize--IconColor);
 
   --ai-project-context--BackgroundColor: var(--ai-general--BackgroundColor);
-  --ai-project-context--LabelBackgroundColor: var(--ai-general-LabelBackgroundColor);
+  --ai-project-context--LabelBackgroundColor: var(--ai-general--LabelBackgroundColor);
   --ai-project-context--BorderColor: var(--ai-general--BorderColor);
   --ai-project-context--SelectedColor: var(--ai-general--SelectedColor);
   --ai-project-context--Color: var(--ai-general--BorderColor);
   --ai-project-context--IconColor: var(--ai-general--IconColor);
 
   --ai-data-connection--BackgroundColor: var(--ai-organize--BackgroundColor);
-  --ai-data-connection--LabelBackgroundColor: var(--ai-organize-LabelBackgroundColor);
+  --ai-data-connection--LabelBackgroundColor: var(--ai-organize--LabelBackgroundColor);
   --ai-data-connection--BorderColor: var(--ai-organize--BorderColor);
   --ai-data-connection--SelectedColor: var(--ai-organize--SelectedColor);
   --ai-data-connection--Color: var(--ai-organize--BorderColor);
   --ai-data-connection--IconColor: var(--ai-organize--IconColor);
 
   --ai-cluster-storage--BackgroundColor: var(--ai-organize--BackgroundColor);
-  --ai-cluster-storage--LabelBackgroundColor: var(--ai-organize-LabelBackgroundColor);
+  --ai-cluster-storage--LabelBackgroundColor: var(--ai-organize--LabelBackgroundColor);
   --ai-cluster-storage--BorderColor: var(--ai-organize--BorderColor);
   --ai-cluster-storage--SelectedColor: var(--ai-organize--SelectedColor);
   --ai-cluster-storage--Color: var(--ai-organize--BorderColor);
   --ai-cluster-storage--IconColor: var(--ai-organize--IconColor);
 
   --ai-notebook--BackgroundColor: var(--ai-training--BackgroundColor);
-  --ai-notebook--LabelBackgroundColor: var(--ai-training-LabelBackgroundColor);
+  --ai-notebook--LabelBackgroundColor: var(--ai-training--LabelBackgroundColor);
   --ai-notebook--BorderColor: var(--ai-training--BorderColor);
   --ai-notebook--SelectedColor: var(--ai-training--SelectedColor);
   --ai-notebook--Color: var(--ai-training--Color);
   --ai-notebook--IconColor: var(--ai-training--IconColor);
 
   --ai-model--BackgroundColor: var(--ai-serving--BackgroundColor);
-  --ai-model--LabelBackgroundColor: var(--ai-serving-LabelBackgroundColor);
+  --ai-model--LabelBackgroundColor: var(--ai-serving--LabelBackgroundColor);
   --ai-model--BorderColor: var(--ai-serving--BorderColor);
   --ai-model--SelectedColor: var(--ai-serving--SelectedColor);
   --ai-model--Color: var(--ai-serving--BorderColor);
   --ai-model--IconColor: var(--ai-serving--IconColor);
 
   --ai-pipeline--BackgroundColor: var(--ai-training--BackgroundColor);
-  --ai-pipeline--LabelBackgroundColor: var(--ai-training-LabelBackgroundColor);
+  --ai-pipeline--LabelBackgroundColor: var(--ai-training--LabelBackgroundColor);
   --ai-pipeline--BorderColor: var(--ai-training--BorderColor);
   --ai-pipeline--SelectedColor: var(--ai-training--SelectedColor);
   --ai-pipeline--Color: var(--ai-training--BorderColor);
   --ai-pipeline--IconColor: var(--ai-training--IconColor);
 
   --ai-model-server--BackgroundColor: var(--ai-serving--BackgroundColor);
-  --ai-model-server--LabelBackgroundColor: var(--ai-serving-LabelBackgroundColor);
+  --ai-model-server--LabelBackgroundColor: var(--ai-serving--LabelBackgroundColor);
   --ai-model-server--BorderColor: var(--ai-serving--BorderColor);
   --ai-model-server--SelectedColor: var(--ai-serving--SelectedColor);
   --ai-model-server--Color: var(--ai-serving--Color);
   --ai-model-server--IconColor: var(--ai-serving--IconColor);
 
   --ai-user--BackgroundColor: var(--ai-set-up--BackgroundColor);
-  --ai-user--LabelBackgroundColor: var(--ai-set-up-LabelBackgroundColor);
+  --ai-user--LabelBackgroundColor: var(--ai-set-up--LabelBackgroundColor);
   --ai-user--BorderColor: var(--ai-set-up--BorderColor);
   --ai-user--SelectedColor: var(--ai-set-up--SelectedColor);
   --ai-user--Color: var(--ai-set-up--BorderColor);
   --ai-user--IconColor: var(--ai-set-up--IconColor);
 
   --ai-group--BackgroundColor: var(--ai-set-up--BackgroundColor);
-  --ai-group--LabelBackgroundColor: var(--ai-set-up-LabelBackgroundColor);
+  --ai-group--LabelBackgroundColor: var(--ai-set-up--LabelBackgroundColor);
   --ai-group--BorderColor: var(--ai-set-up--BorderColor);
   --ai-group--SelectedColor: var(--ai-set-up--SelectedColor);
   --ai-group--Color: var(--ai-set-up--BorderColor);

--- a/mod-arch-shared/components/design/vars.scss
+++ b/mod-arch-shared/components/design/vars.scss
@@ -1,31 +1,182 @@
 :root {
-  --ai-set-up--BackgroundColor: #ffe8cc;
-  --ai-organize--BackgroundColor: #ffe8cc;
-  --ai-training--BackgroundColor: #daf2f2;
-  --ai-serving--BackgroundColor: #e0f0ff;
+  --ai-set-up--BackgroundColor: var(--pf-t--color--orange--10);
+  --ai-set-up--LabelBackgroundColor: var(--pf-t--color--orange--20);
+  --ai-set-up--BorderColor: var(--pf-t--color--orange--30);
+  --ai-set-up--SelectedColor: var(--pf-t--color--orange--40);
+  --ai-set-up--Color: var(--pf-t--color--orange--40);
+  --ai-set-up--IconColor: var(--pf-t--global--text--color--regular);
 
-  --ai-set-up--BorderColor: #f8ae54;
-  --ai-organize--BorderColor: #f8ae54;
-  --ai-training--BorderColor: #9ad8d8;
-  --ai-serving--BorderColor: #92c5f9;
+  --ai-config--BackgroundColor: var(--pf-t--color--orange--10);
+  --ai-config--LabelBackgroundColor: var(--pf-t--color--orange--20);
+  --ai-config--BorderColor: var(--pf-t--color--orange--30);
+  --ai-config--SelectedColor: var(--pf-t--color--orange--40);
+  --ai-config--Color: var(--pf-t--color--orange--40);
+  --ai-config--IconColor: var(--pf-t--global--text--color--regular);
+
+  --ai-organize--BackgroundColor: var(--pf-t--color--orange--10);
+  --ai-organize--LabelBackgroundColor: var(--pf-t--color--orange--20);
+  --ai-organize--BorderColor: var(--pf-t--color--orange--30);
+  --ai-organize--SelectedColor: var(--pf-t--color--orange--40);
+  --ai-organize--Color: var(--pf-t--color--orange--40);
+  --ai-organize--IconColor: var(--pf-t--global--text--color--regular);
+
+  --ai-training--BackgroundColor: var(--pf-t--color--teal--10);
+  --ai-training--LabelBackgroundColor: var(--pf-t--color--teal--20);
+  --ai-training--BorderColor: var(--pf-t--color--teal--30);
+  --ai-training--SelectedColor: var(--pf-t--color--teal--40);
+  --ai-training--Color: var(--pf-t--color--teal--50);
+  --ai-training--IconColor: var(--pf-t--global--text--color--regular);
+
+  --ai-serving--BackgroundColor: var(--pf-t--color--purple--10);
+  --ai-serving--LabelBackgroundColor: var(--pf-t--color--purple--20);
+  --ai-serving--BorderColor: var(--pf-t--color--purple--30);
+  --ai-serving--SelectedColor: var(--pf-t--color--purple--40);
+  --ai-serving--Color: var(--pf-t--color--purple--50);
+  --ai-serving--IconColor: var(--pf-t--global--text--color--regular);
+
+  --ai-general--BackgroundColor: var(--pf-t--color--gray--10);
+  --ai-general--LabelBackgroundColor: var(--pf-t--color--gray--20);
+  --ai-general--BorderColor: var(--pf-t--color--gray--30);
+  --ai-general--SelectedColor: var(--pf-t--color--gray--40);
+  --ai-general--Color:var(--pf-t--color--gray--50);
+  --ai-general--IconColor: var(--pf-t--global--text--color--regular);
 
   --ai-project--BackgroundColor: var(--ai-organize--BackgroundColor);
+  --ai-project--LabelBackgroundColor: var(--ai-organize-LabelBackgroundColor);
   --ai-project--BorderColor: var(--ai-organize--BorderColor);
+  --ai-project--SelectedColor: var(--ai-organize--SelectedColor);
+  --ai-project--Color: var(--ai-organize--BorderColor);
+  --ai-project--IconColor: var(--ai-organize--IconColor);
+
+  --ai-project-context--BackgroundColor: var(--ai-general--BackgroundColor);
+  --ai-project-context--LabelBackgroundColor: var(--ai-general-LabelBackgroundColor);
+  --ai-project-context--BorderColor: var(--ai-general--BorderColor);
+  --ai-project-context--SelectedColor: var(--ai-general--SelectedColor);
+  --ai-project-context--Color: var(--ai-general--BorderColor);
+  --ai-project-context--IconColor: var(--ai-general--IconColor);
+
   --ai-data-connection--BackgroundColor: var(--ai-organize--BackgroundColor);
+  --ai-data-connection--LabelBackgroundColor: var(--ai-organize-LabelBackgroundColor);
   --ai-data-connection--BorderColor: var(--ai-organize--BorderColor);
+  --ai-data-connection--SelectedColor: var(--ai-organize--SelectedColor);
+  --ai-data-connection--Color: var(--ai-organize--BorderColor);
+  --ai-data-connection--IconColor: var(--ai-organize--IconColor);
+
   --ai-cluster-storage--BackgroundColor: var(--ai-organize--BackgroundColor);
+  --ai-cluster-storage--LabelBackgroundColor: var(--ai-organize-LabelBackgroundColor);
   --ai-cluster-storage--BorderColor: var(--ai-organize--BorderColor);
+  --ai-cluster-storage--SelectedColor: var(--ai-organize--SelectedColor);
+  --ai-cluster-storage--Color: var(--ai-organize--BorderColor);
+  --ai-cluster-storage--IconColor: var(--ai-organize--IconColor);
 
   --ai-notebook--BackgroundColor: var(--ai-training--BackgroundColor);
+  --ai-notebook--LabelBackgroundColor: var(--ai-training-LabelBackgroundColor);
   --ai-notebook--BorderColor: var(--ai-training--BorderColor);
+  --ai-notebook--SelectedColor: var(--ai-training--SelectedColor);
+  --ai-notebook--Color: var(--ai-training--Color);
+  --ai-notebook--IconColor: var(--ai-training--IconColor);
+
+  --ai-model--BackgroundColor: var(--ai-serving--BackgroundColor);
+  --ai-model--LabelBackgroundColor: var(--ai-serving-LabelBackgroundColor);
+  --ai-model--BorderColor: var(--ai-serving--BorderColor);
+  --ai-model--SelectedColor: var(--ai-serving--SelectedColor);
+  --ai-model--Color: var(--ai-serving--BorderColor);
+  --ai-model--IconColor: var(--ai-serving--IconColor);
+
   --ai-pipeline--BackgroundColor: var(--ai-training--BackgroundColor);
+  --ai-pipeline--LabelBackgroundColor: var(--ai-training-LabelBackgroundColor);
   --ai-pipeline--BorderColor: var(--ai-training--BorderColor);
+  --ai-pipeline--SelectedColor: var(--ai-training--SelectedColor);
+  --ai-pipeline--Color: var(--ai-training--BorderColor);
+  --ai-pipeline--IconColor: var(--ai-training--IconColor);
 
   --ai-model-server--BackgroundColor: var(--ai-serving--BackgroundColor);
+  --ai-model-server--LabelBackgroundColor: var(--ai-serving-LabelBackgroundColor);
   --ai-model-server--BorderColor: var(--ai-serving--BorderColor);
+  --ai-model-server--SelectedColor: var(--ai-serving--SelectedColor);
+  --ai-model-server--Color: var(--ai-serving--Color);
+  --ai-model-server--IconColor: var(--ai-serving--IconColor);
 
   --ai-user--BackgroundColor: var(--ai-set-up--BackgroundColor);
+  --ai-user--LabelBackgroundColor: var(--ai-set-up-LabelBackgroundColor);
   --ai-user--BorderColor: var(--ai-set-up--BorderColor);
+  --ai-user--SelectedColor: var(--ai-set-up--SelectedColor);
+  --ai-user--Color: var(--ai-set-up--BorderColor);
+  --ai-user--IconColor: var(--ai-set-up--IconColor);
+
   --ai-group--BackgroundColor: var(--ai-set-up--BackgroundColor);
+  --ai-group--LabelBackgroundColor: var(--ai-set-up-LabelBackgroundColor);
   --ai-group--BorderColor: var(--ai-set-up--BorderColor);
+  --ai-group--SelectedColor: var(--ai-set-up--SelectedColor);
+  --ai-group--Color: var(--ai-set-up--BorderColor);
+  --ai-group--IconColor: var(--ai-set-up--IconColor);
+
+  /* Feature Store specific colors */
+  --ai-fs-entity--BackgroundColor: var(--pf-t--color--gray--10);
+  --ai-fs-entity--IconColor: var(--pf-t--global--text--color--regular);
+
+  --ai-fs-data-source--BackgroundColor: var(--pf-t--color--blue--10);
+  --ai-fs-data-source--IconColor: var(--pf-t--global--text--color--regular);
+
+  --ai-fs-data-set--BackgroundColor: var(--pf-t--color--teal--10);
+  --ai-fs-data-set--IconColor: var(--pf-t--global--text--color--regular);
+
+  --ai-fs-feature--BackgroundColor: var(--pf-t--color--orange--10);
+  --ai-fs-feature--IconColor: var(--pf-t--global--text--color--regular);
+
+  --ai-fs-feature-view--BackgroundColor: var(--pf-t--color--purple--10);
+  --ai-fs-feature-view--IconColor: var(--pf-t--global--text--color--regular);
+
+  --ai-fs-feature-service--BackgroundColor: var(--pf-t--color--green--10);
+  --ai-fs-feature-service--IconColor: var(--pf-t--global--text--color--regular);
+
+  --ai-fs-feature-store--BackgroundColor: var(--pf-t--color--gray--10);
+  --ai-fs-feature-store--IconColor: var(--pf-t--global--text--color--regular);
+}
+:root:where(.pf-v6-theme-dark) {
+  --ai-set-up--BackgroundColor: var(--pf-t--color--orange--50);
+  --ai-set-up--IconColor: var(--pf-t--color--white);
+
+  --ai-config--BackgroundColor: var(--pf-t--color--orange--50);
+  --ai-config--IconColor: var(--pf-t--color--white);
+
+  --ai-organize--BackgroundColor: var(--pf-t--color--orange--50);
+  --ai-organize--IconColor: var(--pf-t--color--white);
+
+  --ai-training--BackgroundColor: var(--pf-t--color--teal--50);
+  --ai-training--IconColor: var(--pf-t--color--white);
+
+  --ai-serving--BackgroundColor: var(--pf-t--color--purple--40);
+  --ai-serving--IconColor: var(--pf-t--color--white);
+
+  --ai-general--BackgroundColor: var(--pf-t--color--gray--50);
+  --ai-general--IconColor: var(--pf-t--color--white);
+
+  /* Feature Store dark theme colors */
+  --ai-fs-entity--BackgroundColor: var(--pf-t--color--gray--50);
+  --ai-fs-entity--IconColor: var(--pf-t--color--white);
+
+  --ai-fs-data-source--BackgroundColor: var(--pf-t--color--blue--40);
+  --ai-fs-data-source--IconColor: var(--pf-t--color--white);
+
+  --ai-fs-data-set--BackgroundColor: var(--pf-t--color--teal--50);
+  --ai-fs-data-set--IconColor: var(--pf-t--color--white);
+
+  --ai-fs-feature--BackgroundColor: var(--pf-t--color--orange--50);
+  --ai-fs-feature--IconColor: var(--pf-t--color--white);
+
+  --ai-fs-feature-view--BackgroundColor: var(--pf-t--color--purple--40);
+  --ai-fs-feature-view--IconColor: var(--pf-t--color--white);
+
+  --ai-fs-feature-service--BackgroundColor: var(--pf-t--color--green--50);
+  --ai-fs-feature-service--IconColor: var(--pf-t--color--white);
+
+  --ai-fs-feature-store--BackgroundColor: var(--pf-t--color--gray--50);
+  --ai-fs-feature-store--IconColor: var(--pf-t--color--white);
+}
+
+#tabContent-Lineage .pf-topology-pipelines__status-icon-background.pf-m-idle.pf-m-selected,
+#feature-view-lineage-tab .pf-topology-pipelines__status-icon-background.pf-m-idle.pf-m-selected {
+  fill: var(--pf-t--global--color--brand--default) !important;
+  stroke: var(--pf-t--global--border--color--default) !important;
 }

--- a/mod-arch-shared/index.ts
+++ b/mod-arch-shared/index.ts
@@ -1,4 +1,4 @@
-// Side-effect: shared utility classes (e.g. odh-u-spin) for any package entrypoint.
+// Side-effect: shared utility classes (e.g. ai-u-spin) for any package entrypoint.
 import './components/design/utilities.scss';
 
 // Export components

--- a/mod-arch-shared/index.ts
+++ b/mod-arch-shared/index.ts
@@ -1,3 +1,6 @@
+// Side-effect: shared utility classes (e.g. odh-u-spin) for any package entrypoint.
+import './components/design/utilities.scss';
+
 // Export components
 export * from './components';
 


### PR DESCRIPTION
## Summary

Exports the shared **`.ai-u-spin`** utility from `mod-arch-shared` (same animation PatternFly uses for spinners, applied to icons in dense UI such as labels and tables). Brings **`vars.scss`** in line with the ODH dashboard: PF design tokens, dark-theme overrides, and the full set of AI category / Feature Store variables so shared components don’t drift from the host.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or tooling changes

## Related Issues

Resolves / refs: [RHOAIENG-55744](https://redhat.atlassian.net/browse/RHOAIENG-55744) (follow-up to [RHOAIENG-38486](https://redhat.atlassian.net/browse/RHOAIENG-38486))

## Changes Made

- Add `mod-arch-shared/components/design/utilities.scss` with `.odh-u-spin` using `pf-v6-c-spinner-animation-rotate` (same behavior as the previous host-only rule in ODH `App.scss`).

- Import that stylesheet from the package entry (`mod-arch-shared/index.ts`) as a side effect so any app that imports from `mod-arch-shared` loads the utility (including federated remotes that should not depend on host global CSS).

- Replace `mod-arch-shared/components/design/vars.scss` with the dashboard-aligned version: `--pf-t--*` tokens, `:root:where(.pf-v6-theme-dark)` overrides, and categories including config, general, model, project-context, Feature Store, plus the lineage topology fill/stroke overrides.

## Testing

### How to Test

1. From repo root: `npm install` (if needed), then `npm run build:shared` and `npm run test:shared`.
2. In a consumer (e.g. ODH dashboard after bumping `mod-arch-shared`), confirm components using `className="odh-u-spin"` still animate and AI-related colors match the main app.

### Test Results

- [ ] Unit tests pass (`npm test`)
- [ ] Lint checks pass (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
- [ ] No new warnings introduced
- [x] Changes are backwards compatible (or breaking changes are documented)

## Screenshots / Output

N/A (styling/tokens; no UI screenshot required for the library change alone).

## Additional Notes

- **ODH dashboard follow-up (separate PR):** remove the duplicate `.odh-u-spin` block from `frontend/src/app/App

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added a reusable spin utility for continuous rotation animations.
  * Expanded semantic design tokens for many UI categories and Feature Store components, now using PatternFly theme variables for consistent colors.
  * Ensured certain topology pipeline icons render correct brand/border colors in selected idle states.

* **New Features**
  * Added dark-theme overrides so component and feature colors adapt automatically in dark mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->