### PR TITLE
fix(kubeflow): align PF status and label tokens with MUI palette

### DIFF
--- a/mod-arch-kubeflow/style/MUI-theme.scss
+++ b/mod-arch-kubeflow/style/MUI-theme.scss
@@ -35,7 +35,6 @@
   --pf-t--global--color--brand--default: var(--mui-palette-primary-main);
   --pf-t--global--color--brand--hover: var(--mui-palette-primary-dark);
   --pf-t--global--color--brand--clicked: var(--mui-palette-primary-dark);
-  --pf-t--global--color--nonstatus--blue--default: var(--mui-palette-primary-main);
 
   // ═══════════════════════════════════════════════════════════════════════════
   // BACKGROUND COLORS (47+ components affected)
@@ -128,11 +127,21 @@
   --pf-t--global--color--status--warning--default: var(--mui-palette-warning-main);
   --pf-t--global--color--status--success--default: var(--mui-palette-success-main);
   --pf-t--global--color--status--info--default: var(--mui-palette-info-main);
+
+  // Status Non-Status Colors
+  --pf-t--global--color--nonstatus--blue--default: var(--mui-palette-primary-light);
+  --pf-t--global--color--nonstatus--blue--hover: var(--mui-palette-primary-light);
   
   --pf-t--global--icon--color--status--danger--default: var(--mui-palette-error-main);
   --pf-t--global--icon--color--status--warning--default: var(--mui-palette-warning-main);
   --pf-t--global--icon--color--status--success--default: var(--mui-palette-success-main);
   --pf-t--global--icon--color--status--info--default: var(--mui-palette-info-main);
+
+  // Status Hover Colors (for labels, alerts, etc.)
+  --pf-t--global--color--status--warning--hover: var(--mui-palette-warning-main);
+  --pf-t--global--color--status--success--hover: var(--mui-palette-success-main);
+  --pf-t--global--color--status--info--hover: var(--mui-palette-info-main);
+  --pf-t--global--color--status--danger--hover: var(--mui-palette-error-main);
   
   // Status Border Colors (for alerts, form validation, etc.)
   --pf-t--global--border--color--status--danger--default: var(--mui-palette-error-main);
@@ -140,8 +149,19 @@
   --pf-t--global--border--color--status--success--default: var(--mui-palette-success-main);
   --pf-t--global--border--color--status--info--default: var(--mui-palette-info-main);
 
+  // Status Border Hover Colors (for labels, alerts, etc.)
+  --pf-t--global--border--color--status--warning--hover: var(--mui-palette-warning-main);
+  --pf-t--global--border--color--status--success--hover: var(--mui-palette-success-main);
+  --pf-t--global--border--color--status--info--hover: var(--mui-palette-info-main);
+  --pf-t--global--border--color--status--danger--hover: var(--mui-palette-error-main);
+
   // MUI's warning background is darker than PF's default yellow, requiring white text for contrast
   --pf-t--global--text--color--status--on-warning--default: var(--mui-palette-warning-contrastText);
+  --pf-t--global--text--color--status--on-warning--hover: var(--mui-palette-warning-contrastText);
+
+  // Status Non-Status Text Colors for blue labels
+  --pf-t--global--text--color--nonstatus--on-blue--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-blue--hover: var(--pf-t--global--text--color--inverse);
 
   // ═══════════════════════════════════════════════════════════════════════════
   // MUI CUSTOM VARIABLES
@@ -1841,19 +1861,10 @@ left: 0;
   --pf-v6-c-button--PaddingInlineEnd: var(--mui-spacing-4px);
 }
 
-.mui-theme .pf-v6-c-label {
-  --pf-v6-c-label--m-blue--Color: var(--pf-t--global--text--color--inverse);
-}
-
 .mui-theme .pf-v6-c-label-group.pf-m-category {
   --pf-v6-c-label-group--m-category--BorderWidth: 0px;
   // Border radius inherited from --pf-t--global--border--radius--small (set to MUI shape-borderRadius)
   box-shadow: var(--mui-shadows-1);
-}
-
-.mui-theme .pf-v6-c-label.pf-m-outline {
-  --pf-v6-c-label--BorderColor: none;
-  --pf-v6-c-label--BackgroundColor: var(--mui-palette-grey-200);
 }
 
 .mui-theme .pf-v6-c-masthead {

--- a/mod-arch-kubeflow/style/MUI-theme.scss
+++ b/mod-arch-kubeflow/style/MUI-theme.scss
@@ -138,6 +138,10 @@
   --pf-t--global--icon--color--status--success--default: var(--mui-palette-success-main);
   --pf-t--global--icon--color--status--info--default: var(--mui-palette-info-main);
 
+  // Non-Status Icon Colors
+  --pf-t--global--icon--color--nonstatus--on-blue--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-blue--hover: var(--pf-t--global--icon--color--inverse);
+
   // Status Hover Colors (for labels, alerts, etc.)
   --pf-t--global--color--status--warning--hover: var(--mui-palette-warning-main);
   --pf-t--global--color--status--success--hover: var(--mui-palette-success-main);

--- a/mod-arch-kubeflow/style/MUI-theme.scss
+++ b/mod-arch-kubeflow/style/MUI-theme.scss
@@ -129,8 +129,8 @@
   --pf-t--global--color--status--info--default: var(--mui-palette-info-main);
 
   // Non-Status Colors
-  --pf-t--global--color--nonstatus--blue--default: var(--mui-palette-primary-light);
-  --pf-t--global--color--nonstatus--blue--hover: var(--mui-palette-primary-light);
+  --pf-t--global--color--nonstatus--blue--default: var(--mui-palette-primary-main);
+  --pf-t--global--color--nonstatus--blue--hover: var(--mui-palette-primary-main);
 
   // Status Icon Colors
   --pf-t--global--icon--color--status--danger--default: var(--mui-palette-error-main);
@@ -155,7 +155,7 @@
   --pf-t--global--border--color--status--info--default: var(--mui-palette-info-main);
 
   // Non-Status Border Colors
-  --pf-t--global--border--color--nonstatus--blue--default: var(--mui-palette-primary-light);
+  --pf-t--global--border--color--nonstatus--blue--default: var(--mui-palette-primary-main);
 
   // Status Border Hover Colors (for labels, alerts, etc.)
   --pf-t--global--border--color--status--warning--hover: var(--mui-palette-warning-main);

--- a/mod-arch-kubeflow/style/MUI-theme.scss
+++ b/mod-arch-kubeflow/style/MUI-theme.scss
@@ -128,10 +128,11 @@
   --pf-t--global--color--status--success--default: var(--mui-palette-success-main);
   --pf-t--global--color--status--info--default: var(--mui-palette-info-main);
 
-  // Status Non-Status Colors
+  // Non-Status Colors
   --pf-t--global--color--nonstatus--blue--default: var(--mui-palette-primary-light);
   --pf-t--global--color--nonstatus--blue--hover: var(--mui-palette-primary-light);
-  
+
+  // Status Icon Colors
   --pf-t--global--icon--color--status--danger--default: var(--mui-palette-error-main);
   --pf-t--global--icon--color--status--warning--default: var(--mui-palette-warning-main);
   --pf-t--global--icon--color--status--success--default: var(--mui-palette-success-main);
@@ -149,11 +150,17 @@
   --pf-t--global--border--color--status--success--default: var(--mui-palette-success-main);
   --pf-t--global--border--color--status--info--default: var(--mui-palette-info-main);
 
+  // Non-Status Border Colors
+  --pf-t--global--border--color--nonstatus--blue--default: var(--mui-palette-primary-light);
+
   // Status Border Hover Colors (for labels, alerts, etc.)
   --pf-t--global--border--color--status--warning--hover: var(--mui-palette-warning-main);
   --pf-t--global--border--color--status--success--hover: var(--mui-palette-success-main);
   --pf-t--global--border--color--status--info--hover: var(--mui-palette-info-main);
   --pf-t--global--border--color--status--danger--hover: var(--mui-palette-error-main);
+
+  // Non-Status Border Hover Colors
+  --pf-t--global--border--color--nonstatus--blue--hover: var(--mui-palette-primary-light);
 
   // MUI's warning background is darker than PF's default yellow, requiring white text for contrast
   --pf-t--global--text--color--status--on-warning--default: var(--mui-palette-warning-contrastText);


### PR DESCRIPTION
## Summary

Aligns PatternFly status/label tokens with MUI palette values so that labels (filled, outline, and status variants) render correct colors in MUI theme mode without needing extra component-level overrides.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or tooling changes

## Related Issues

<!-- Link to related Jira tickets or GitHub issues -->

## Changes Made

- Moved `--pf-t--global--color--nonstatus--blue--default` from `primary-main` to `primary-light` and added the corresponding `--hover` token
- Added status hover color tokens (`warning`, `success`, `info`, `danger`) so filled/outline label hover states resolve correctly
- Added status border hover color tokens for the same four statuses
- Added nonstatus blue border color tokens (`--pf-t--global--border--color--nonstatus--blue--default` and `--hover`) mapped to `primary-light`
- Added `--pf-t--global--text--color--status--on-warning--hover` for label text contrast on warning hover
- Added `--pf-t--global--text--color--nonstatus--on-blue--default` and `--hover` so blue labels get inverse text
- Removed the `.mui-theme .pf-v6-c-label` block that hard-coded `--m-blue--Color` (now handled by the global nonstatus token)
- Removed the `.mui-theme .pf-v6-c-label.pf-m-outline` block that set `BorderColor: none` and a grey background (outline labels now follow SSOT tokens)
- Reorganized section comments for status icon, non-status, and border token groups

## Testing

### How to Test

1. Build and pack the kubeflow package:
   ```bash
   cd mod-arch-kubeflow && npm run build && npm pack
   ```
2. Install the tarball in your consumer app:
   ```bash
   cd /path/to/app && npm install /path/to/mod-arch-kubeflow/mod-arch-kubeflow-0.0.0-semantically-released.tgz
   ```
3. Start the app and verify PatternFly labels (filled, outline, blue, status variants) display correct background, border, and text colors
4. Hover over clickable labels and confirm hover states match MUI palette values

### Test Results

- [ ] Unit tests pass (`npm test`)
- [ ] Lint checks pass (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes are backwards compatible (or breaking changes are documented)

## Screenshots / Output

<!-- If applicable, add screenshots or command output -->
Before:

<img width="2302" height="1016" alt="Screenshot 2026-04-09 at 12 43 58 PM" src="https://github.com/user-attachments/assets/a211ffa3-7eb0-4efe-9219-f5a249e460d3" />
<img width="2302" height="1016" alt="Screenshot 2026-04-09 at 12 43 52 PM" src="https://github.com/user-attachments/assets/a96ab9ca-fd93-47cc-90d7-b28c84876198" />
<img width="2302" height="1016" alt="Screenshot 2026-04-09 at 12 43 38 PM" src="https://github.com/user-attachments/assets/051ba164-8a12-4c4d-8882-01c4b6e63c57" />
<img width="2302" height="1016" alt="Screenshot 2026-04-09 at 12 43 33 PM" src="https://github.com/user-attachments/assets/624fb986-4c21-4b44-bce3-d6e191f9b94e" />

After:

<img width="2302" height="1016" alt="Screenshot 2026-04-09 at 12 20 02 PM" src="https://github.com/user-attachments/assets/5481d72b-a25b-4e04-a223-0b72303bcb2a" />
<img width="2302" height="1016" alt="Screenshot 2026-04-09 at 12 39 23 PM" src="https://github.com/user-attachments/assets/71a59286-e5de-4725-bd62-2cec766331ec" />
<img width="2302" height="1016" alt="Screenshot 2026-04-09 at 12 39 18 PM" src="https://github.com/user-attachments/assets/14f4e0e1-016c-4c5d-8fb0-5b95a35bdc50" />
<img width="2302" height="1016" alt="Screenshot 2026-04-09 at 12 20 09 PM" src="https://github.com/user-attachments/assets/d2b4a93f-21ed-4ec3-afd1-d2f4880a73ab" />

## Additional Notes

This change shifts label styling from component-level overrides to global design tokens, which is the preferred approach per the SCSS architecture rules. Outline labels will now show their default SSOT border color instead of `none`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated blue and status color palette and hover states for interactive elements (non-status and status: warning, success, info, danger).
  * Refined border colors and hover behavior for improved visual consistency.
  * Consolidated label and component theming by centralizing color tokens for more consistent styling across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->