### PR TITLE
fix(webpack): allow @odh-dashboard packages to be transpiled from nod…

### DIFF
--- a/mod-arch-installer/flavors/default/frontend/config/webpack.common.js
+++ b/mod-arch-installer/flavors/default/frontend/config/webpack.common.js
@@ -35,8 +35,7 @@ module.exports = (env) => ({
     rules: [
       {
         test: /\.(tsx|ts|jsx|js)?$/,
-        exclude: [/node_modules/, /__tests__/, /__mocks__/],
-        include: [SRC_DIR, COMMON_DIR, INTERNAL_DIR],
+        exclude: [/node_modules\/(?!@odh-dashboard)/, /__tests__/, /__mocks__/],
         use: [
           COVERAGE === 'true' && '@jsdevtools/coverage-istanbul-loader',
           env === 'development'

--- a/mod-arch-starter/frontend/config/webpack.common.js
+++ b/mod-arch-starter/frontend/config/webpack.common.js
@@ -39,8 +39,7 @@ module.exports = (env) => ({
     rules: [
       {
         test: /\.(tsx|ts|jsx|js)?$/,
-        exclude: [/node_modules/, /__tests__/, /__mocks__/],
-        include: [SRC_DIR, COMMON_DIR],
+        exclude: [/node_modules\/(?!@odh-dashboard)/, /__tests__/, /__mocks__/],
         use: [
           COVERAGE === 'true' && '@jsdevtools/coverage-istanbul-loader',
           env === 'development'


### PR DESCRIPTION
## Summary

Replace the `include` allowlist + blanket `node_modules` exclude in webpack's TS/JS loader rule with a single permissive `exclude` that carves out `@odh-dashboard` packages. This lets dashboard packages installed in `node_modules` be transpiled without having to enumerate every source directory in `include`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or tooling changes

## Related Issues

## Changes Made

- **`mod-arch-starter/frontend/config/webpack.common.js`** (kubeflow flavor source of truth): Replaced `exclude: [/node_modules/, ...]` + `include: [SRC_DIR, COMMON_DIR]` with `exclude: [/node_modules\/(?!@odh-dashboard)/, /__tests__/, /__mocks__/]` and no `include`.
- **`mod-arch-installer/flavors/default/frontend/config/webpack.common.js`** (default/federated flavor overlay): Same change — replaced `exclude` + `include: [SRC_DIR, COMMON_DIR, INTERNAL_DIR]` with the permissive `exclude`. `INTERNAL_DIR` (`../../../frontend/src`) is not under `node_modules`, so it continues to be compiled without an explicit `include`.

## Testing

### How to Test

1. Build the installer: `npm run build --workspace=mod-arch-installer`
2. Scaffold a kubeflow project: `npx mod-arch-installer test-project --flavor kubeflow --no-git`
3. Verify `test-project/frontend/config/webpack.common.js` has `exclude: [/node_modules\/(?!@odh-dashboard)/, ...]` and no `include` on the TS/JS rule.
4. Scaffold a default project: `npx mod-arch-installer test-project-default --flavor default --no-git`
5. Verify the same exclude pattern in the default project's webpack config.
6. Run `npm run build` in a scaffolded project to confirm webpack compiles successfully.

### Test Results

- [ ] Unit tests pass (`npm test`)
- [ ] Lint checks pass (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Manual testing completed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes are backwards compatible (or breaking changes are documented)

## Screenshots / Output

## Additional Notes

- The `templates/` directory in `mod-arch-installer` is gitignored and regenerated at build time by `sync-templates`, so only the starter and flavors files need to be maintained.
- The `INTERNAL_DIR` variable in the default flavor's config is now unused by the TS/JS rule but is still declared (used elsewhere for documentation/reference). Could be cleaned up in a follow-up.