### PR TITLE
fix: remove redundant prepublishOnly scripts breaking release pipeline

### DIFF
--- a/mod-arch-core/package.json
+++ b/mod-arch-core/package.json
@@ -24,8 +24,7 @@
     "test:unit": "npm run test:jest -- --silent",
     "test:type-check": "tsc --noEmit",
     "test:fix": "eslint --ext .js,.ts,.jsx,.tsx . --fix",
-    "test:lint": "eslint --max-warnings 0 --ext .js,.ts,.jsx,.tsx .",
-    "prepublishOnly": "npm run build && npm run test"
+    "test:lint": "eslint --max-warnings 0 --ext .js,.ts,.jsx,.tsx ."
   },
   "repository": {
     "type": "git",

--- a/mod-arch-kubeflow/package.json
+++ b/mod-arch-kubeflow/package.json
@@ -27,8 +27,7 @@
     "test:unit": "npm run test:jest -- --silent",
     "test:type-check": "tsc --noEmit",
     "test:fix": "eslint --ext .js,.ts,.jsx,.tsx . --fix",
-    "test:lint": "eslint --max-warnings 0 --ext .js,.ts,.jsx,.tsx .",
-    "prepublishOnly": "npm run build && npm run test"
+    "test:lint": "eslint --max-warnings 0 --ext .js,.ts,.jsx,.tsx ."
   },
   "repository": {
     "type": "git",

--- a/mod-arch-shared/package.json
+++ b/mod-arch-shared/package.json
@@ -25,8 +25,7 @@
     "test:unit": "npm run test:jest -- --silent",
     "test:type-check": "tsc --noEmit",
     "test:fix": "eslint --ext .js,.ts,.jsx,.tsx . --fix",
-    "test:lint": "eslint --max-warnings 0 --ext .js,.ts,.jsx,.tsx .",
-    "prepublishOnly": "npm run build && npm run test"
+    "test:lint": "eslint --max-warnings 0 --ext .js,.ts,.jsx,.tsx ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Fix the release pipeline that has been failing to publish `mod-arch-shared` and `mod-arch-installer` since April 2026. The root cause is that `npm publish --workspaces --provenance` with a granular access token consistently fails with E401 on the 3rd workspace package. Publishing each workspace individually avoids this batch auth/provenance issue.

Also removes redundant `prepublishOnly` scripts that duplicated work already done by CI.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI/CD or tooling changes

## Related Issues

Resolves: [RHOAIENG-58158](https://redhat.atlassian.net/browse/RHOAIENG-58158)

## Changes Made

- Changed `publishCmd` in `.releaserc.json` from `npm publish --workspaces --provenance --access public` to individual per-workspace publish commands (`npm publish -w <pkg>`)
- Removed `prepublishOnly: "npm run build && npm run test"` from `mod-arch-core/package.json`, `mod-arch-kubeflow/package.json`, and `mod-arch-shared/package.json` (redundant with CI steps)

## Testing

### How to Test

1. Merge this PR — the `fix:` commit will trigger a patch release via semantic-release
2. Verify the release workflow publishes all 4 packages (`mod-arch-core`, `mod-arch-kubeflow`, `mod-arch-shared`, `mod-arch-installer`) successfully to npm at the same version
3. Check https://www.npmjs.com/package/mod-arch-shared to confirm it advances past 1.12.1

### Test Results

- [x] Unit tests pass (`npm test`)
- [x] Lint checks pass (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes are backwards compatible (or breaking changes are documented)

## Additional Notes

**Root cause:** `npm publish --workspaces --provenance` with a granular access token fails on the 3rd workspace with `401 Unauthorized - Failed to generate Web Auth URLs due to error: BadRequestError: token is invalid`. The provenance attestation is signed to Sigstore before the PUT, but the npm registry rejects the upload. This happens regardless of lifecycle scripts or timing — tested in under 8 seconds total with no prepublishOnly scripts.

**Impact:** `mod-arch-shared` and `mod-arch-installer` have been stuck at 1.12.1 since Apr 2, while `mod-arch-core` and `mod-arch-kubeflow` advanced to 1.15.1.

**Fix:** Publish each workspace individually (`npm publish -w <pkg>`) instead of batching with `--workspaces`, so each publish is an independent auth+provenance operation.

Failed runs (all same error on mod-arch-shared):
- [Apr 14 — after prepublishOnly removal, confirms it's not the cause](https://github.com/opendatahub-io/mod-arch-library/actions/runs/24410236578)
- [Apr 10](https://github.com/opendatahub-io/mod-arch-library/actions/runs/24263597918)
- [Apr 9](https://github.com/opendatahub-io/mod-arch-library/actions/runs/24204259281)