### PR TITLE
feat(bff): add inter-BFF communication scaffolding

### DIFF
--- a/mod-arch-installer/flavors/default/bff/cmd/main.go
+++ b/mod-arch-installer/flavors/default/bff/cmd/main.go
@@ -46,6 +46,11 @@ func main() {
 	// TLS configuration flags
 	flag.BoolVar(&cfg.InsecureSkipVerify, "insecure-skip-verify", getEnvAsBool("INSECURE_SKIP_VERIFY", false), "Skip TLS certificate verification (useful for development, default: false)")
 
+	// ─── BFF Inter-Communication ─────────────────────────────────
+	flag.BoolVar(&cfg.MockBFFClients, "mock-bff-clients",
+		getEnvAsBool("MOCK_BFF_CLIENTS", false),
+		"Enable mock BFF clients (no real HTTP calls to other BFFs)")
+
 	// Deprecated flags - kept for backward compatibility
 	flag.BoolVar(&cfg.StandaloneMode, "standalone-mode", false, "DEPRECATED: Use -deployment-mode=standalone instead")
 	flag.BoolVar(&cfg.FederatedPlatform, "federated-platform", false, "DEPRECATED: Use -deployment-mode=federated instead")

--- a/mod-arch-installer/flavors/default/bff/internal/config/environment.go
+++ b/mod-arch-installer/flavors/default/bff/internal/config/environment.go
@@ -98,6 +98,11 @@ type EnvConfig struct {
 	// Default is false (secure) for production environments
 	InsecureSkipVerify bool
 
+	// ─── BFF INTER-COMMUNICATION ─────────────────────────────────
+	// MockBFFClients enables mock mode for BFF inter-communication clients.
+	// When true, BFF clients return mock responses instead of making real HTTP calls.
+	MockBFFClients bool
+
 	// ─── DEPRECATED ─────────────────────────────────────────────
 	// The following fields are deprecated and maintained for backward compatibility
 	// Use DeploymentMode instead

--- a/mod-arch-starter/bff/README.md
+++ b/mod-arch-starter/bff/README.md
@@ -60,6 +60,7 @@ make run LOG_LEVEL=DEBUG
 | `-cert-file` | `CERT_FILE` | TLS certificate path (enables TLS when paired with key) |
 | `-key-file` | `KEY_FILE` | TLS key path |
 | `-insecure-skip-verify` | `INSECURE_SKIP_VERIFY` | Skip upstream TLS verify (dev only) |
+| `-mock-bff-clients` | `MOCK_BFF_CLIENTS` | Use mock BFF clients (no real HTTP calls to other BFFs) |
 
 TLS: If both `cert-file` and `key-file` are provided the server starts with HTTPS.
 
@@ -110,7 +111,37 @@ curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/user
 curl -i -H "kubeflow-userid: user@example.com" localhost:4000/api/v1/namespaces   # (dev / mock only)
 ```
 
-<!-- Minimal scope: all former Mod Arch examples removed -->
+### Inter-BFF Communication
+
+The BFF includes a `bffclient` package (`internal/integrations/bffclient/`) that provides the scaffolding for calling other BFF services in a multi-BFF pod deployment. The package is target-agnostic — teams wire up their own target BFF endpoints on top of this infrastructure.
+
+#### Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                        ODH Dashboard Pod                     │
+├──────────────────────────────────────────────────────────────┤
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────┐   │
+│  │  Gen-AI BFF  │──│   MaaS BFF   │──│ Model Registry   │   │
+│  │    :8143     │  │    :8243     │  │   BFF :8043      │   │
+│  └──────────────┘  └──────────────┘  └──────────────────┘   │
+│         │                  │                    │            │
+│  ┌──────────────┐          │                    │            │
+│  │  MLflow BFF  │──────────┴────────────────────┘            │
+│  │    :8343     │     Inter-BFF HTTP Calls                   │
+│  └──────────────┘  (K8s service DNS or localhost)            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+#### Adding a BFF target
+
+1. Add target-specific config fields to `internal/config/environment.go` (e.g. `BFF<Target>ServiceName`, `BFF<Target>ServicePort`, etc.)
+2. Add corresponding CLI flags to `cmd/main.go`
+3. Apply config overrides in `NewApp()` in `internal/api/app.go`
+4. Create a handler in `internal/api/` using `bffclient.GetClient()` and `bffclient.AttachBFFClient()` middleware
+5. Wire routes in `Routes()`
+
+See the `bffclient` package README and the implementation spec for detailed guidance.
 
 ### Authentication modes
 

--- a/mod-arch-starter/bff/cmd/main.go
+++ b/mod-arch-starter/bff/cmd/main.go
@@ -53,6 +53,11 @@ func main() {
 	// TLS configuration flags
 	flag.BoolVar(&cfg.InsecureSkipVerify, "insecure-skip-verify", getEnvAsBool("INSECURE_SKIP_VERIFY", false), "Skip TLS certificate verification (useful for development, default: false)")
 
+	// ─── BFF Inter-Communication ─────────────────────────────────
+	flag.BoolVar(&cfg.MockBFFClients, "mock-bff-clients",
+		getEnvAsBool("MOCK_BFF_CLIENTS", false),
+		"Enable mock BFF clients (no real HTTP calls to other BFFs)")
+
 	// Deprecated flags - kept for backward compatibility
 	flag.BoolVar(&cfg.StandaloneMode, "standalone-mode", false, "DEPRECATED: Use -deployment-mode=standalone instead")
 	flag.BoolVar(&cfg.FederatedPlatform, "federated-platform", false, "DEPRECATED: Use -deployment-mode=federated instead")

--- a/mod-arch-starter/bff/internal/api/app.go
+++ b/mod-arch-starter/bff/internal/api/app.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/bffclient"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/bffclient/bffmocks"
 	k8s "github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/kubernetes"
 	k8mocks "github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/kubernetes/k8mocks"
 	"k8s.io/client-go/kubernetes"
@@ -28,8 +30,8 @@ const (
 	PathPrefix      = "/mod-arch"
 	ApiPathPrefix   = "/api/v1"
 	HealthCheckPath = "/healthcheck"
-	UserPath        = ApiPathPrefix + "/user"
-	NamespacePath   = ApiPathPrefix + "/namespaces"
+	UserPath      = ApiPathPrefix + "/user"
+	NamespacePath = ApiPathPrefix + "/namespaces"
 )
 
 type App struct {
@@ -41,6 +43,8 @@ type App struct {
 	testEnv *envtest.Environment
 	// rootCAs used for outbound TLS connections to Client Service
 	rootCAs *x509.CertPool
+	// bffClientFactory creates clients for inter-BFF communication
+	bffClientFactory bffclient.BFFClientFactory
 }
 
 func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
@@ -109,6 +113,29 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 
+	// Initialize BFF client factory for inter-BFF communication
+	var bffFactory bffclient.BFFClientFactory
+	bffConfig := bffclient.NewDefaultBFFClientConfig()
+	bffConfig.MockBFFClients = cfg.MockBFFClients
+	bffConfig.InsecureSkipVerify = cfg.InsecureSkipVerify
+
+	// Apply target-specific configuration overrides from CLI flags/env vars here.
+	// Example: to configure a target BFF, add fields to EnvConfig and apply them:
+	//
+	//   if targetCfg := bffConfig.GetServiceConfig(bffclient.BFFTargetMaaS); targetCfg != nil {
+	//       targetCfg.ServiceName = cfg.BFFTargetServiceName
+	//       targetCfg.Port = cfg.BFFTargetServicePort
+	//       targetCfg.DevOverrideURL = cfg.BFFTargetDevURL
+	//   }
+
+	if cfg.MockBFFClients {
+		logger.Info("Using mock BFF client factory")
+		bffFactory = bffmocks.NewMockClientFactory(logger)
+	} else {
+		logger.Info("Using real BFF client factory")
+		bffFactory = bffclient.NewRealClientFactory(bffConfig, rootCAs, cfg.InsecureSkipVerify, logger)
+	}
+
 	app := &App{
 		config:                  cfg,
 		logger:                  logger,
@@ -116,6 +143,7 @@ func NewApp(cfg config.EnvConfig, logger *slog.Logger) (*App, error) {
 		repositories:            repositories.NewRepositories(),
 		testEnv:                 testEnv,
 		rootCAs:                 rootCAs,
+		bffClientFactory:        bffFactory,
 	}
 	return app, nil
 }
@@ -140,6 +168,14 @@ func (app *App) Routes() http.Handler {
 	// Minimal Kubernetes-backed starter endpoints
 	apiRouter.GET(UserPath, app.UserHandler)
 	apiRouter.GET(NamespacePath, app.GetNamespacesHandler)
+
+	// Inter-BFF Communication routes — wire your target BFF endpoints here.
+	// Example:
+	//
+	//   apiRouter.POST(ApiPathPrefix+"/bff/<target>/endpoint",
+	//       app.AttachNamespace(
+	//           bffclient.AttachBFFClient(app.bffClientFactory, bffclient.BFFTarget<Target>)(
+	//               app.YourHandler)))
 
 	// App Router
 	appMux := http.NewServeMux()

--- a/mod-arch-starter/bff/internal/api/public_helpers.go
+++ b/mod-arch-starter/bff/internal/api/public_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/opendatahub-io/mod-arch-library/bff/internal/config"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/bffclient"
 	k8s "github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/kubernetes"
 	"github.com/opendatahub-io/mod-arch-library/bff/internal/repositories"
 )
@@ -71,4 +72,10 @@ func (app *App) KubernetesClientFactory() k8s.KubernetesClientFactory { //nolint
 // This allows downstream extensions to access the repositories.
 func (app *App) Repositories() *repositories.Repositories { //nolint:unused
 	return app.repositories
+}
+
+// BFFClientFactory returns the BFF client factory for inter-BFF communication.
+// This allows downstream extensions to create BFF clients.
+func (app *App) BFFClientFactory() bffclient.BFFClientFactory { //nolint:unused
+	return app.bffClientFactory
 }

--- a/mod-arch-starter/bff/internal/config/environment.go
+++ b/mod-arch-starter/bff/internal/config/environment.go
@@ -108,6 +108,11 @@ type EnvConfig struct {
 	// Default is false (secure) for production environments
 	InsecureSkipVerify bool
 
+	// ─── BFF INTER-COMMUNICATION ─────────────────────────────────
+	// MockBFFClients enables mock mode for BFF inter-communication clients.
+	// When true, BFF clients return mock responses instead of making real HTTP calls.
+	MockBFFClients bool
+
 	// ─── DEPRECATED ─────────────────────────────────────────────
 	// The following fields are deprecated and maintained for backward compatibility
 	// Use DeploymentMode instead

--- a/mod-arch-starter/bff/internal/constants/keys.go
+++ b/mod-arch-starter/bff/internal/constants/keys.go
@@ -20,3 +20,13 @@ const (
 	TraceIdKey     contextKey = "TraceIdKey"
 	TraceLoggerKey contextKey = "TraceLoggerKey"
 )
+
+// BFFTarget represents a target BFF service (re-exported from bffclient package)
+type BFFTarget string
+
+// BFFClientKey returns a context key for storing BFF clients by target.
+// This allows multiple BFF clients to be stored in the same context.
+// Usage: ctx.Value(constants.BFFClientKey("maas"))
+func BFFClientKey(target BFFTarget) contextKey {
+	return contextKey("BFFClientKey_" + string(target))
+}

--- a/mod-arch-starter/bff/internal/integrations/bffclient/README.md
+++ b/mod-arch-starter/bff/internal/integrations/bffclient/README.md
@@ -1,0 +1,85 @@
+# bffclient — Inter-BFF Communication Package
+
+Self-contained HTTP client package for calling other Backend-for-Frontend (BFF) services
+in a multi-container Kubernetes pod deployment.
+
+## Package Structure
+
+```
+bffclient/
+├── client.go           # HTTP client with TLS, auth forwarding, response parsing
+├── client_test.go      # Client unit tests
+├── config.go           # Service discovery, URL generation, default configuration
+├── config_test.go      # Config unit tests
+├── errors.go           # Structured error types with 10 error codes
+├── errors_test.go      # Error unit tests
+├── factory.go          # Factory pattern for real/mock client creation
+├── factory_test.go     # Factory unit tests
+├── middleware.go        # Context injection middleware (httprouter + http.HandlerFunc)
+└── bffmocks/
+    └── mock_client.go  # Thread-safe mock implementation for testing
+```
+
+## Port Assignments
+
+| BFF              | Port | BFFTarget Constant |
+|------------------|------|--------------------|
+| Model Registry   | 8043 | `model-registry`   |
+| Gen-AI           | 8143 | `gen-ai`           |
+| MaaS             | 8243 | `maas`             |
+| MLflow           | 8343 | `mlflow`           |
+
+## Usage
+
+### 1. Middleware — attach a BFF client to request context
+
+```go
+apiRouter.POST("/api/v1/bff/<target>/endpoint",
+    app.AttachNamespace(
+        bffclient.AttachBFFClient(app.bffClientFactory, bffclient.BFFTarget<Target>)(
+            app.YourHandler)))
+```
+
+### 2. Handler — retrieve client and make calls
+
+```go
+func (app *App) YourHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+    client := bffclient.GetClient(r.Context(), bffclient.BFFTarget<Target>)
+    if client == nil {
+        // handle unavailable
+        return
+    }
+
+    var response YourResponseType
+    err := client.Call(r.Context(), "POST", "/your-endpoint", requestBody, &response)
+    // handle err / write response
+}
+```
+
+### 3. Testing — inject mock client via context
+
+```go
+mockClient := bffmocks.NewMockBFFClient(bffclient.BFFTarget<Target>)
+ctx := context.WithValue(req.Context(),
+    constants.BFFClientKey("<target>"), mockClient)
+req = req.WithContext(ctx)
+```
+
+## Configuration
+
+See the BFF README and the inter-BFF communication spec for environment variables,
+CLI flags, and Kubernetes manifest changes.
+
+## Design Decisions
+
+- **Self-contained**: each BFF includes its own copy (no shared Go module)
+- **Middleware-based**: follows the same pattern as other BFF middleware
+- **Auth forwarding**: transparently forwards user tokens to the target BFF
+- **Mock support**: full mock mode for testing without running other BFFs
+- **Best-effort health checks**: availability checks log warnings but don't block
+
+## Running Tests
+
+```bash
+go test ./internal/integrations/bffclient/... -v
+```

--- a/mod-arch-starter/bff/internal/integrations/bffclient/bffmocks/mock_client.go
+++ b/mod-arch-starter/bff/internal/integrations/bffclient/bffmocks/mock_client.go
@@ -1,0 +1,142 @@
+package bffmocks
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/bffclient"
+)
+
+// MockBFFClient provides a mock implementation of the BFFClientInterface for testing
+type MockBFFClient struct {
+	target    bffclient.BFFTarget
+	baseURL   string
+	available bool
+
+	// CallHandler allows customizing the mock response for specific calls
+	// If nil, default mock responses are used
+	CallHandler func(ctx context.Context, method, path string, body interface{}, response interface{}) error
+}
+
+// NewMockBFFClient creates a new mock BFF client
+func NewMockBFFClient(target bffclient.BFFTarget) *MockBFFClient {
+	return &MockBFFClient{
+		target:    target,
+		baseURL:   fmt.Sprintf("http://mock-%s.test.svc.cluster.local:8080/api/v1", target),
+		available: true,
+	}
+}
+
+// Call returns mock responses based on the configured CallHandler.
+// Set CallHandler to customize responses for your target BFF's endpoints.
+// Without a CallHandler, returns a NOT_FOUND error for all calls.
+func (m *MockBFFClient) Call(ctx context.Context, method, path string, body interface{}, response interface{}) error {
+	if m.CallHandler != nil {
+		return m.CallHandler(ctx, method, path, body, response)
+	}
+
+	return bffclient.NewNotFoundError(m.target, fmt.Sprintf("mock not implemented for %s %s on target %s — set CallHandler to customize", method, path, m.target))
+}
+
+// IsAvailable returns the mock availability status
+func (m *MockBFFClient) IsAvailable(_ context.Context) bool {
+	return m.available
+}
+
+// GetBaseURL returns the mock base URL
+func (m *MockBFFClient) GetBaseURL() string {
+	return m.baseURL
+}
+
+// GetTarget returns the target BFF identifier
+func (m *MockBFFClient) GetTarget() bffclient.BFFTarget {
+	return m.target
+}
+
+// SetAvailable allows tests to control the availability status
+func (m *MockBFFClient) SetAvailable(available bool) {
+	m.available = available
+}
+
+// MockClientFactory creates mock BFF clients for testing
+type MockClientFactory struct {
+	config    *bffclient.BFFClientConfig
+	clients   map[bffclient.BFFTarget]*MockBFFClient
+	clientsMu sync.RWMutex
+	logger    *slog.Logger
+}
+
+// NewMockClientFactory creates a new mock client factory
+func NewMockClientFactory(logger *slog.Logger) bffclient.BFFClientFactory {
+	config := bffclient.NewDefaultBFFClientConfig()
+	config.MockBFFClients = true
+
+	return &MockClientFactory{
+		config:  config,
+		clients: make(map[bffclient.BFFTarget]*MockBFFClient),
+		logger:  logger,
+	}
+}
+
+// CreateClient creates a new mock BFF client for the specified target
+func (f *MockClientFactory) CreateClient(target bffclient.BFFTarget, authToken string) bffclient.BFFClientInterface {
+	return f.CreateClientWithHeaders(target, authToken, nil)
+}
+
+// CreateClientWithHeaders creates a new mock BFF client (headers are ignored in mock)
+func (f *MockClientFactory) CreateClientWithHeaders(target bffclient.BFFTarget, _ string, _ map[string]string) bffclient.BFFClientInterface {
+	// Check if client already exists (read lock)
+	f.clientsMu.RLock()
+	if client, ok := f.clients[target]; ok {
+		f.clientsMu.RUnlock()
+		return client
+	}
+	f.clientsMu.RUnlock()
+
+	// Create new mock client (write lock)
+	f.clientsMu.Lock()
+	defer f.clientsMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if client, ok := f.clients[target]; ok {
+		return client
+	}
+
+	client := NewMockBFFClient(target)
+	f.clients[target] = client
+
+	if f.logger != nil {
+		f.logger.Debug("Created mock BFF client", "target", target)
+	}
+
+	return client
+}
+
+// GetConfig returns the configuration for a specific target
+func (f *MockClientFactory) GetConfig(target bffclient.BFFTarget) *bffclient.BFFServiceConfig {
+	return f.config.GetServiceConfig(target)
+}
+
+// IsTargetConfigured always returns true for mock factory (all targets available)
+func (f *MockClientFactory) IsTargetConfigured(_ bffclient.BFFTarget) bool {
+	return true
+}
+
+// GetMockClient returns the mock client for a specific target (for test assertions)
+func (f *MockClientFactory) GetMockClient(target bffclient.BFFTarget) *MockBFFClient {
+	f.clientsMu.RLock()
+	defer f.clientsMu.RUnlock()
+	return f.clients[target]
+}
+
+// NewMockClientFactoryWithConfig creates a new mock client factory with custom config
+func NewMockClientFactoryWithConfig(config *bffclient.BFFClientConfig, _ *x509.CertPool, _ bool, logger *slog.Logger) bffclient.BFFClientFactory {
+	return &MockClientFactory{
+		config:  config,
+		clients: make(map[bffclient.BFFTarget]*MockBFFClient),
+		logger:  logger,
+	}
+}

--- a/mod-arch-starter/bff/internal/integrations/bffclient/client.go
+++ b/mod-arch-starter/bff/internal/integrations/bffclient/client.go
@@ -1,0 +1,213 @@
+package bffclient
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// BFFClientInterface defines the interface for inter-BFF communication
+type BFFClientInterface interface {
+	// Call makes a request to the target BFF
+	// method: HTTP method (GET, POST, PUT, DELETE, etc.)
+	// path: API path (e.g., "/tokens")
+	// body: request body (will be JSON encoded, nil for no body)
+	// response: pointer to response struct (will be JSON decoded)
+	Call(ctx context.Context, method, path string, body interface{}, response interface{}) error
+
+	// IsAvailable checks if the target BFF is reachable (best effort health check)
+	IsAvailable(ctx context.Context) bool
+
+	// GetBaseURL returns the target BFF's base URL
+	GetBaseURL() string
+
+	// GetTarget returns the target BFF identifier
+	GetTarget() BFFTarget
+}
+
+// HTTPBFFClient implements BFFClientInterface using HTTP requests
+type HTTPBFFClient struct {
+	baseURL         string
+	target          BFFTarget
+	httpClient      *http.Client
+	authToken       string
+	customHeaders   map[string]string
+	authTokenHeader string // Header to send auth token in (e.g., "x-forwarded-access-token")
+	authTokenPrefix string // Prefix for auth token (e.g., "" or "Bearer ")
+}
+
+// NewHTTPBFFClient creates a new HTTP-based BFF client
+func NewHTTPBFFClient(baseURL string, target BFFTarget, authToken string, insecureSkipVerify bool, rootCAs *x509.CertPool) *HTTPBFFClient {
+	return NewHTTPBFFClientWithConfig(baseURL, target, authToken, nil, "", "", insecureSkipVerify, rootCAs)
+}
+
+// NewHTTPBFFClientWithHeaders creates a new HTTP-based BFF client with custom headers
+func NewHTTPBFFClientWithHeaders(baseURL string, target BFFTarget, authToken string, customHeaders map[string]string, insecureSkipVerify bool, rootCAs *x509.CertPool) *HTTPBFFClient {
+	return NewHTTPBFFClientWithConfig(baseURL, target, authToken, customHeaders, "", "", insecureSkipVerify, rootCAs)
+}
+
+// NewHTTPBFFClientWithConfig creates a new HTTP-based BFF client with full auth configuration
+func NewHTTPBFFClientWithConfig(baseURL string, target BFFTarget, authToken string, customHeaders map[string]string, authTokenHeader string, authTokenPrefix string, insecureSkipVerify bool, rootCAs *x509.CertPool) *HTTPBFFClient {
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: insecureSkipVerify,
+	}
+	if rootCAs != nil {
+		tlsConfig.RootCAs = rootCAs
+	}
+
+	return &HTTPBFFClient{
+		baseURL:         baseURL,
+		target:          target,
+		authToken:       authToken,
+		customHeaders:   customHeaders,
+		authTokenHeader: authTokenHeader,
+		authTokenPrefix: authTokenPrefix,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
+		},
+	}
+}
+
+// Call makes a request to the target BFF
+func (c *HTTPBFFClient) Call(ctx context.Context, method, path string, body interface{}, response interface{}) error {
+	url := c.baseURL + path
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			return NewBFFClientErrorWithTarget(ErrCodeInternalError, fmt.Sprintf("failed to marshal request body: %v", err), c.target, 500)
+		}
+		bodyReader = bytes.NewBuffer(bodyBytes)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return NewBFFClientErrorWithTarget(ErrCodeInternalError, fmt.Sprintf("failed to create request: %v", err), c.target, 500)
+	}
+
+	// Set headers
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	// Forward auth token using configured header and prefix
+	if c.authToken != "" {
+		header := c.authTokenHeader
+		if header == "" {
+			header = "x-forwarded-access-token" // Default for ODH
+		}
+		req.Header.Set(header, c.authTokenPrefix+c.authToken)
+	}
+
+	// Set custom headers (e.g., kubeflow-userid for internal auth)
+	for key, value := range c.customHeaders {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		// Provide more specific error messages for common failure modes
+		if errors.Is(err, context.DeadlineExceeded) {
+			return NewConnectionError(c.target, fmt.Sprintf("request to %s BFF timed out", c.target))
+		}
+		if errors.Is(err, context.Canceled) {
+			return NewConnectionError(c.target, fmt.Sprintf("request to %s BFF was canceled", c.target))
+		}
+		return NewConnectionError(c.target, fmt.Sprintf("failed to connect to %s BFF: %v", c.target, err))
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return NewInvalidResponseError(c.target, fmt.Sprintf("failed to read response body: %v", err))
+	}
+
+	// Handle error status codes
+	if resp.StatusCode >= 400 {
+		return c.handleErrorResponse(resp.StatusCode, respBody)
+	}
+
+	// Decode response body if response pointer provided
+	if response != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, response); err != nil {
+			// Include truncated body in error for debugging
+			bodyPreview := string(respBody)
+			if len(bodyPreview) > 200 {
+				bodyPreview = bodyPreview[:200] + "..."
+			}
+			return NewInvalidResponseError(c.target, fmt.Sprintf("failed to unmarshal response: %v (body: %q)", err, bodyPreview))
+		}
+	}
+
+	return nil
+}
+
+// handleErrorResponse maps HTTP error codes to BFF client errors
+func (c *HTTPBFFClient) handleErrorResponse(statusCode int, body []byte) error {
+	message := string(body)
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+
+	switch statusCode {
+	case http.StatusBadRequest:
+		return NewBadRequestError(c.target, message)
+	case http.StatusUnauthorized:
+		return NewUnauthorizedError(c.target, message)
+	case http.StatusForbidden:
+		return NewForbiddenError(c.target, message)
+	case http.StatusNotFound:
+		return NewNotFoundError(c.target, message)
+	case http.StatusServiceUnavailable:
+		return NewServerUnavailableError(c.target)
+	default:
+		if statusCode >= 500 {
+			return NewServerUnavailableError(c.target)
+		}
+		return NewBFFClientErrorWithTarget(ErrCodeInternalError, message, c.target, statusCode)
+	}
+}
+
+// IsAvailable performs a best-effort health check to the target BFF
+func (c *HTTPBFFClient) IsAvailable(ctx context.Context) bool {
+	// Create a context with a short timeout for health check
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	// Try to reach the health endpoint
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/healthcheck", nil)
+	if err != nil {
+		return false
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == http.StatusOK
+}
+
+// GetBaseURL returns the target BFF's base URL
+func (c *HTTPBFFClient) GetBaseURL() string {
+	return c.baseURL
+}
+
+// GetTarget returns the target BFF identifier
+func (c *HTTPBFFClient) GetTarget() BFFTarget {
+	return c.target
+}

--- a/mod-arch-starter/bff/internal/integrations/bffclient/client_test.go
+++ b/mod-arch-starter/bff/internal/integrations/bffclient/client_test.go
@@ -1,0 +1,245 @@
+package bffclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPBFFClient_Call_Success(t *testing.T) {
+	expected := map[string]string{"status": "ok"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expected)
+	}))
+	defer server.Close()
+
+	client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "", false, nil)
+
+	var result map[string]string
+	err := client.Call(context.Background(), http.MethodGet, "/test", nil, &result)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result["status"])
+}
+
+func TestHTTPBFFClient_Call_WithBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		var body map[string]string
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "test-value", body["key"])
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"created": "true"})
+	}))
+	defer server.Close()
+
+	client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "", false, nil)
+
+	var result map[string]string
+	err := client.Call(context.Background(), http.MethodPost, "/create", map[string]string{"key": "test-value"}, &result)
+
+	require.NoError(t, err)
+	assert.Equal(t, "true", result["created"])
+}
+
+func TestHTTPBFFClient_Call_AuthTokenForwarding(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "test-token", r.Header.Get("x-forwarded-access-token"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "test-token", false, nil)
+	err := client.Call(context.Background(), http.MethodGet, "/test", nil, nil)
+
+	require.NoError(t, err)
+}
+
+func TestHTTPBFFClient_Call_CustomAuthHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer my-token", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPBFFClientWithConfig(
+		server.URL, BFFTargetMaaS, "my-token", nil,
+		"Authorization", "Bearer ", false, nil,
+	)
+	err := client.Call(context.Background(), http.MethodGet, "/test", nil, nil)
+
+	require.NoError(t, err)
+}
+
+func TestHTTPBFFClient_Call_CustomHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "user@example.com", r.Header.Get("kubeflow-userid"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	headers := map[string]string{"kubeflow-userid": "user@example.com"}
+	client := NewHTTPBFFClientWithHeaders(server.URL, BFFTargetMaaS, "", headers, false, nil)
+	err := client.Call(context.Background(), http.MethodGet, "/test", nil, nil)
+
+	require.NoError(t, err)
+}
+
+func TestHTTPBFFClient_Call_ErrorCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantCode   string
+	}{
+		{"bad request", http.StatusBadRequest, ErrCodeBadRequest},
+		{"unauthorized", http.StatusUnauthorized, ErrCodeUnauthorized},
+		{"forbidden", http.StatusForbidden, ErrCodeForbidden},
+		{"not found", http.StatusNotFound, ErrCodeNotFound},
+		{"service unavailable", http.StatusServiceUnavailable, ErrCodeServerUnavailable},
+		{"internal server error", http.StatusInternalServerError, ErrCodeServerUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte("error message"))
+			}))
+			defer server.Close()
+
+			client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "", false, nil)
+			err := client.Call(context.Background(), http.MethodGet, "/test", nil, nil)
+
+			require.Error(t, err)
+			var bffErr *BFFClientError
+			require.ErrorAs(t, err, &bffErr)
+			assert.Equal(t, tt.wantCode, bffErr.Code)
+			assert.Equal(t, BFFTargetMaaS, bffErr.Target)
+		})
+	}
+}
+
+func TestHTTPBFFClient_Call_ConnectionError(t *testing.T) {
+	// Use a server that is immediately closed
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	server.Close()
+
+	client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "", false, nil)
+	err := client.Call(context.Background(), http.MethodGet, "/test", nil, nil)
+
+	require.Error(t, err)
+	var bffErr *BFFClientError
+	require.ErrorAs(t, err, &bffErr)
+	assert.Equal(t, ErrCodeConnectionFailed, bffErr.Code)
+}
+
+func TestHTTPBFFClient_Call_ContextCanceled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slow handler
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "", false, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	err := client.Call(ctx, http.MethodGet, "/test", nil, nil)
+	require.Error(t, err)
+}
+
+func TestHTTPBFFClient_Call_InvalidResponseJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("not-json"))
+	}))
+	defer server.Close()
+
+	client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "", false, nil)
+
+	var result map[string]string
+	err := client.Call(context.Background(), http.MethodGet, "/test", nil, &result)
+
+	require.Error(t, err)
+	var bffErr *BFFClientError
+	require.ErrorAs(t, err, &bffErr)
+	assert.Equal(t, ErrCodeInvalidResponse, bffErr.Code)
+}
+
+func TestHTTPBFFClient_IsAvailable(t *testing.T) {
+	t.Run("available", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/healthcheck", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "", false, nil)
+		assert.True(t, client.IsAvailable(context.Background()))
+	})
+
+	t.Run("unavailable", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "", false, nil)
+		assert.False(t, client.IsAvailable(context.Background()))
+	})
+
+	t.Run("connection refused", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		server.Close()
+
+		client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "", false, nil)
+		assert.False(t, client.IsAvailable(context.Background()))
+	})
+}
+
+func TestHTTPBFFClient_GetBaseURL(t *testing.T) {
+	client := NewHTTPBFFClient("http://test:8080/api/v1", BFFTargetMaaS, "", false, nil)
+	assert.Equal(t, "http://test:8080/api/v1", client.GetBaseURL())
+}
+
+func TestHTTPBFFClient_GetTarget(t *testing.T) {
+	client := NewHTTPBFFClient("http://test:8080", BFFTargetGenAI, "", false, nil)
+	assert.Equal(t, BFFTargetGenAI, client.GetTarget())
+}
+
+func TestHTTPBFFClient_Call_NoResponsePointer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "", false, nil)
+	err := client.Call(context.Background(), http.MethodDelete, "/test", nil, nil)
+
+	require.NoError(t, err)
+}
+
+func TestHTTPBFFClient_Call_EmptyErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	client := NewHTTPBFFClient(server.URL, BFFTargetMaaS, "", false, nil)
+	err := client.Call(context.Background(), http.MethodGet, "/test", nil, nil)
+
+	require.Error(t, err)
+	var bffErr *BFFClientError
+	require.ErrorAs(t, err, &bffErr)
+	assert.Equal(t, ErrCodeBadRequest, bffErr.Code)
+	// Empty body should fall back to http.StatusText
+	assert.Equal(t, "Bad Request", bffErr.Message)
+}

--- a/mod-arch-starter/bff/internal/integrations/bffclient/config.go
+++ b/mod-arch-starter/bff/internal/integrations/bffclient/config.go
@@ -1,0 +1,160 @@
+package bffclient
+
+import (
+	"fmt"
+	"os"
+)
+
+// BFFTarget represents a target BFF service
+type BFFTarget string
+
+const (
+	BFFTargetMaaS          BFFTarget = "maas"
+	BFFTargetGenAI         BFFTarget = "gen-ai"
+	BFFTargetModelRegistry BFFTarget = "model-registry"
+	BFFTargetMLflow        BFFTarget = "mlflow"
+)
+
+// BFFServiceConfig holds configuration for connecting to a BFF service
+type BFFServiceConfig struct {
+	// Target BFF identifier
+	Target BFFTarget
+
+	// ServiceName is the Kubernetes service name
+	ServiceName string
+
+	// Namespace is the Kubernetes namespace (empty = same namespace as caller)
+	Namespace string
+
+	// Port is the service port
+	Port int
+
+	// PathPrefix is the API path prefix (e.g., "/api/v1")
+	PathPrefix string
+
+	// TLSEnabled enables HTTPS communication
+	TLSEnabled bool
+
+	// DevOverrideURL allows local development override
+	DevOverrideURL string
+
+	// ─── AUTH CONFIGURATION ─────────────────────────────────
+	// AuthMethod specifies the auth method the target BFF uses
+	// Supported values: "internal" (kubeflow-userid), "user_token" (token in header)
+	AuthMethod string
+
+	// AuthTokenHeader is the header the target BFF expects for user_token auth
+	// e.g., "x-forwarded-access-token" or "Authorization"
+	AuthTokenHeader string
+
+	// AuthTokenPrefix is the prefix the target BFF expects in the token header
+	// e.g., "" (empty) or "Bearer "
+	AuthTokenPrefix string
+}
+
+// BFFClientConfig holds configuration for the BFF client system
+type BFFClientConfig struct {
+	// MockBFFClients enables mock mode for all BFF clients
+	MockBFFClients bool
+
+	// ServiceConfigs maps target BFFs to their configurations
+	ServiceConfigs map[BFFTarget]*BFFServiceConfig
+
+	// PodNamespace is the namespace where this pod is running (from downward API)
+	PodNamespace string
+
+	// InsecureSkipVerify skips TLS certificate verification (for development)
+	InsecureSkipVerify bool
+}
+
+// NewDefaultBFFClientConfig creates a default BFF client configuration
+// with all known BFF targets configured for the standard single-pod deployment
+func NewDefaultBFFClientConfig() *BFFClientConfig {
+	return &BFFClientConfig{
+		MockBFFClients: false,
+		ServiceConfigs: map[BFFTarget]*BFFServiceConfig{
+			BFFTargetMaaS: {
+				Target:          BFFTargetMaaS,
+				ServiceName:     "odh-dashboard",
+				Port:            8243,
+				PathPrefix:      "/api/v1",
+				TLSEnabled:      false,
+				AuthMethod:      "user_token",
+				AuthTokenHeader: "x-forwarded-access-token",
+				AuthTokenPrefix: "",
+			},
+			BFFTargetGenAI: {
+				Target:          BFFTargetGenAI,
+				ServiceName:     "odh-dashboard",
+				Port:            8143,
+				PathPrefix:      "/api/v1",
+				TLSEnabled:      false,
+				AuthMethod:      "user_token",
+				AuthTokenHeader: "x-forwarded-access-token",
+				AuthTokenPrefix: "",
+			},
+			BFFTargetModelRegistry: {
+				Target:          BFFTargetModelRegistry,
+				ServiceName:     "odh-dashboard",
+				Port:            8043,
+				PathPrefix:      "/api/v1",
+				TLSEnabled:      false,
+				AuthMethod:      "user_token",
+				AuthTokenHeader: "x-forwarded-access-token",
+				AuthTokenPrefix: "",
+			},
+			BFFTargetMLflow: {
+				Target:          BFFTargetMLflow,
+				ServiceName:     "odh-dashboard",
+				Port:            8343,
+				PathPrefix:      "/api/v1",
+				TLSEnabled:      false,
+				AuthMethod:      "user_token",
+				AuthTokenHeader: "x-forwarded-access-token",
+				AuthTokenPrefix: "",
+			},
+		},
+		PodNamespace:       "",
+		InsecureSkipVerify: false,
+	}
+}
+
+// GetURL returns the fully qualified URL for the target BFF service
+func (c *BFFServiceConfig) GetURL(podNamespace string) string {
+	// Priority 1: Dev override URL (for local development)
+	if c.DevOverrideURL != "" {
+		return c.DevOverrideURL
+	}
+
+	// Priority 2: Kubernetes service discovery
+	scheme := "http"
+	if c.TLSEnabled {
+		scheme = "https"
+	}
+
+	namespace := c.Namespace
+	if namespace == "" {
+		namespace = podNamespace
+		if namespace == "" {
+			// Try to get from environment (downward API)
+			namespace = os.Getenv("POD_NAMESPACE")
+		}
+	}
+
+	// If still no namespace, use a reasonable default
+	if namespace == "" {
+		namespace = "opendatahub"
+	}
+
+	// Full DNS: <service>.<namespace>.svc.cluster.local:<port>
+	return fmt.Sprintf("%s://%s.%s.svc.cluster.local:%d%s",
+		scheme, c.ServiceName, namespace, c.Port, c.PathPrefix)
+}
+
+// GetServiceConfig returns the configuration for a specific target BFF
+func (c *BFFClientConfig) GetServiceConfig(target BFFTarget) *BFFServiceConfig {
+	if config, ok := c.ServiceConfigs[target]; ok {
+		return config
+	}
+	return nil
+}

--- a/mod-arch-starter/bff/internal/integrations/bffclient/config_test.go
+++ b/mod-arch-starter/bff/internal/integrations/bffclient/config_test.go
@@ -1,0 +1,134 @@
+package bffclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDefaultBFFClientConfig(t *testing.T) {
+	cfg := NewDefaultBFFClientConfig()
+
+	assert.False(t, cfg.MockBFFClients)
+	assert.False(t, cfg.InsecureSkipVerify)
+	assert.Empty(t, cfg.PodNamespace)
+
+	// Verify all targets are configured
+	assert.NotNil(t, cfg.GetServiceConfig(BFFTargetMaaS))
+	assert.NotNil(t, cfg.GetServiceConfig(BFFTargetGenAI))
+	assert.NotNil(t, cfg.GetServiceConfig(BFFTargetModelRegistry))
+	assert.NotNil(t, cfg.GetServiceConfig(BFFTargetMLflow))
+}
+
+func TestBFFServiceConfig_GetURL_DevOverride(t *testing.T) {
+	cfg := &BFFServiceConfig{
+		ServiceName:    "odh-dashboard",
+		Port:           8243,
+		PathPrefix:     "/api/v1",
+		DevOverrideURL: "http://localhost:4000/api/v1",
+	}
+
+	// Dev override takes priority over everything
+	assert.Equal(t, "http://localhost:4000/api/v1", cfg.GetURL("test-namespace"))
+}
+
+func TestBFFServiceConfig_GetURL_KubernetesDiscovery(t *testing.T) {
+	cfg := &BFFServiceConfig{
+		ServiceName: "odh-dashboard",
+		Port:        8243,
+		PathPrefix:  "/api/v1",
+		TLSEnabled:  false,
+	}
+
+	url := cfg.GetURL("my-namespace")
+	assert.Equal(t, "http://odh-dashboard.my-namespace.svc.cluster.local:8243/api/v1", url)
+}
+
+func TestBFFServiceConfig_GetURL_TLSEnabled(t *testing.T) {
+	cfg := &BFFServiceConfig{
+		ServiceName: "odh-dashboard",
+		Port:        8243,
+		PathPrefix:  "/api/v1",
+		TLSEnabled:  true,
+	}
+
+	url := cfg.GetURL("my-namespace")
+	assert.Equal(t, "https://odh-dashboard.my-namespace.svc.cluster.local:8243/api/v1", url)
+}
+
+func TestBFFServiceConfig_GetURL_ExplicitNamespace(t *testing.T) {
+	cfg := &BFFServiceConfig{
+		ServiceName: "odh-dashboard",
+		Namespace:   "explicit-ns",
+		Port:        8243,
+		PathPrefix:  "/api/v1",
+	}
+
+	// Explicit namespace takes priority over podNamespace
+	url := cfg.GetURL("pod-namespace")
+	assert.Equal(t, "http://odh-dashboard.explicit-ns.svc.cluster.local:8243/api/v1", url)
+}
+
+func TestBFFServiceConfig_GetURL_FallbackNamespace(t *testing.T) {
+	cfg := &BFFServiceConfig{
+		ServiceName: "odh-dashboard",
+		Port:        8243,
+		PathPrefix:  "/api/v1",
+	}
+
+	// With no namespace at all, falls back to "opendatahub"
+	url := cfg.GetURL("")
+	assert.Equal(t, "http://odh-dashboard.opendatahub.svc.cluster.local:8243/api/v1", url)
+}
+
+func TestBFFServiceConfig_GetURL_EnvNamespace(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "env-namespace")
+
+	cfg := &BFFServiceConfig{
+		ServiceName: "odh-dashboard",
+		Port:        8243,
+		PathPrefix:  "/api/v1",
+	}
+
+	url := cfg.GetURL("")
+	assert.Equal(t, "http://odh-dashboard.env-namespace.svc.cluster.local:8243/api/v1", url)
+}
+
+func TestBFFClientConfig_GetServiceConfig(t *testing.T) {
+	cfg := NewDefaultBFFClientConfig()
+
+	t.Run("existing target", func(t *testing.T) {
+		maasConfig := cfg.GetServiceConfig(BFFTargetMaaS)
+		require.NotNil(t, maasConfig)
+		assert.Equal(t, BFFTargetMaaS, maasConfig.Target)
+		assert.Equal(t, 8243, maasConfig.Port)
+	})
+
+	t.Run("non-existing target", func(t *testing.T) {
+		result := cfg.GetServiceConfig(BFFTarget("unknown"))
+		assert.Nil(t, result)
+	})
+}
+
+func TestDefaultPortAssignments(t *testing.T) {
+	cfg := NewDefaultBFFClientConfig()
+
+	tests := []struct {
+		target BFFTarget
+		port   int
+	}{
+		{BFFTargetModelRegistry, 8043},
+		{BFFTargetGenAI, 8143},
+		{BFFTargetMaaS, 8243},
+		{BFFTargetMLflow, 8343},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.target), func(t *testing.T) {
+			config := cfg.GetServiceConfig(tt.target)
+			require.NotNil(t, config)
+			assert.Equal(t, tt.port, config.Port)
+		})
+	}
+}

--- a/mod-arch-starter/bff/internal/integrations/bffclient/errors.go
+++ b/mod-arch-starter/bff/internal/integrations/bffclient/errors.go
@@ -1,0 +1,98 @@
+package bffclient
+
+import (
+	"fmt"
+)
+
+// BFFClientError represents BFF client-specific errors
+type BFFClientError struct {
+	Code       string    `json:"code"`
+	Message    string    `json:"message"`
+	Target     BFFTarget `json:"target,omitempty"`
+	StatusCode int       `json:"-"`
+}
+
+func (e *BFFClientError) Error() string {
+	if e.Target != "" {
+		return fmt.Sprintf("BFF client error [%s] for target %s: %s", e.Code, e.Target, e.Message)
+	}
+	return fmt.Sprintf("BFF client error [%s]: %s", e.Code, e.Message)
+}
+
+// BFF client error codes
+const (
+	ErrCodeConnectionFailed  = "CONNECTION_FAILED"
+	ErrCodeTimeout           = "TIMEOUT"
+	ErrCodeInvalidResponse   = "INVALID_RESPONSE"
+	ErrCodeServerUnavailable = "SERVER_UNAVAILABLE"
+	ErrCodeUnauthorized      = "UNAUTHORIZED"
+	ErrCodeForbidden         = "FORBIDDEN"
+	ErrCodeNotFound          = "NOT_FOUND"
+	ErrCodeBadRequest        = "BAD_REQUEST"
+	ErrCodeInternalError     = "INTERNAL_ERROR"
+	ErrCodeNotConfigured     = "NOT_CONFIGURED"
+)
+
+// NewBFFClientError creates a new BFF client error
+func NewBFFClientError(code, message string, statusCode int) *BFFClientError {
+	return &BFFClientError{
+		Code:       code,
+		Message:    message,
+		StatusCode: statusCode,
+	}
+}
+
+// NewBFFClientErrorWithTarget creates a new BFF client error with target information
+func NewBFFClientErrorWithTarget(code, message string, target BFFTarget, statusCode int) *BFFClientError {
+	return &BFFClientError{
+		Code:       code,
+		Message:    message,
+		Target:     target,
+		StatusCode: statusCode,
+	}
+}
+
+// NewConnectionError creates a connection-related error
+func NewConnectionError(target BFFTarget, message string) *BFFClientError {
+	return NewBFFClientErrorWithTarget(ErrCodeConnectionFailed, message, target, 503)
+}
+
+// NewTimeoutError creates a timeout error
+func NewTimeoutError(target BFFTarget) *BFFClientError {
+	return NewBFFClientErrorWithTarget(ErrCodeTimeout, "Request to target BFF timed out", target, 408)
+}
+
+// NewInvalidResponseError creates an invalid response error
+func NewInvalidResponseError(target BFFTarget, message string) *BFFClientError {
+	return NewBFFClientErrorWithTarget(ErrCodeInvalidResponse, message, target, 502)
+}
+
+// NewServerUnavailableError creates a server unavailable error
+func NewServerUnavailableError(target BFFTarget) *BFFClientError {
+	return NewBFFClientErrorWithTarget(ErrCodeServerUnavailable, "Target BFF service is not available", target, 503)
+}
+
+// NewUnauthorizedError creates an unauthorized error
+func NewUnauthorizedError(target BFFTarget, message string) *BFFClientError {
+	return NewBFFClientErrorWithTarget(ErrCodeUnauthorized, message, target, 401)
+}
+
+// NewForbiddenError creates a forbidden error
+func NewForbiddenError(target BFFTarget, message string) *BFFClientError {
+	return NewBFFClientErrorWithTarget(ErrCodeForbidden, message, target, 403)
+}
+
+// NewNotFoundError creates a not found error
+func NewNotFoundError(target BFFTarget, message string) *BFFClientError {
+	return NewBFFClientErrorWithTarget(ErrCodeNotFound, message, target, 404)
+}
+
+// NewBadRequestError creates a bad request error
+func NewBadRequestError(target BFFTarget, message string) *BFFClientError {
+	return NewBFFClientErrorWithTarget(ErrCodeBadRequest, message, target, 400)
+}
+
+// NewNotConfiguredError creates an error for when a target BFF is not configured
+func NewNotConfiguredError(target BFFTarget) *BFFClientError {
+	return NewBFFClientErrorWithTarget(ErrCodeNotConfigured, fmt.Sprintf("Target BFF %s is not configured", target), target, 503)
+}

--- a/mod-arch-starter/bff/internal/integrations/bffclient/errors_test.go
+++ b/mod-arch-starter/bff/internal/integrations/bffclient/errors_test.go
@@ -1,0 +1,108 @@
+package bffclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBFFClientError_Error(t *testing.T) {
+	t.Run("with target", func(t *testing.T) {
+		err := NewBFFClientErrorWithTarget(ErrCodeConnectionFailed, "connection refused", BFFTargetMaaS, 503)
+		assert.Equal(t, "BFF client error [CONNECTION_FAILED] for target maas: connection refused", err.Error())
+	})
+
+	t.Run("without target", func(t *testing.T) {
+		err := NewBFFClientError(ErrCodeInternalError, "something went wrong", 500)
+		assert.Equal(t, "BFF client error [INTERNAL_ERROR]: something went wrong", err.Error())
+	})
+}
+
+func TestErrorConstructors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        *BFFClientError
+		wantCode   string
+		wantStatus int
+		wantTarget BFFTarget
+	}{
+		{
+			name:       "connection error",
+			err:        NewConnectionError(BFFTargetMaaS, "connection refused"),
+			wantCode:   ErrCodeConnectionFailed,
+			wantStatus: 503,
+			wantTarget: BFFTargetMaaS,
+		},
+		{
+			name:       "timeout error",
+			err:        NewTimeoutError(BFFTargetGenAI),
+			wantCode:   ErrCodeTimeout,
+			wantStatus: 408,
+			wantTarget: BFFTargetGenAI,
+		},
+		{
+			name:       "invalid response error",
+			err:        NewInvalidResponseError(BFFTargetModelRegistry, "bad json"),
+			wantCode:   ErrCodeInvalidResponse,
+			wantStatus: 502,
+			wantTarget: BFFTargetModelRegistry,
+		},
+		{
+			name:       "server unavailable error",
+			err:        NewServerUnavailableError(BFFTargetMLflow),
+			wantCode:   ErrCodeServerUnavailable,
+			wantStatus: 503,
+			wantTarget: BFFTargetMLflow,
+		},
+		{
+			name:       "unauthorized error",
+			err:        NewUnauthorizedError(BFFTargetMaaS, "invalid token"),
+			wantCode:   ErrCodeUnauthorized,
+			wantStatus: 401,
+			wantTarget: BFFTargetMaaS,
+		},
+		{
+			name:       "forbidden error",
+			err:        NewForbiddenError(BFFTargetMaaS, "access denied"),
+			wantCode:   ErrCodeForbidden,
+			wantStatus: 403,
+			wantTarget: BFFTargetMaaS,
+		},
+		{
+			name:       "not found error",
+			err:        NewNotFoundError(BFFTargetMaaS, "endpoint not found"),
+			wantCode:   ErrCodeNotFound,
+			wantStatus: 404,
+			wantTarget: BFFTargetMaaS,
+		},
+		{
+			name:       "bad request error",
+			err:        NewBadRequestError(BFFTargetMaaS, "invalid input"),
+			wantCode:   ErrCodeBadRequest,
+			wantStatus: 400,
+			wantTarget: BFFTargetMaaS,
+		},
+		{
+			name:       "not configured error",
+			err:        NewNotConfiguredError(BFFTargetMaaS),
+			wantCode:   ErrCodeNotConfigured,
+			wantStatus: 503,
+			wantTarget: BFFTargetMaaS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantCode, tt.err.Code)
+			assert.Equal(t, tt.wantStatus, tt.err.StatusCode)
+			assert.Equal(t, tt.wantTarget, tt.err.Target)
+			assert.NotEmpty(t, tt.err.Error())
+		})
+	}
+}
+
+func TestBFFClientError_ImplementsErrorInterface(t *testing.T) {
+	var err error = NewConnectionError(BFFTargetMaaS, "test")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "CONNECTION_FAILED")
+}

--- a/mod-arch-starter/bff/internal/integrations/bffclient/factory.go
+++ b/mod-arch-starter/bff/internal/integrations/bffclient/factory.go
@@ -1,0 +1,84 @@
+package bffclient
+
+import (
+	"crypto/x509"
+	"log/slog"
+)
+
+// BFFClientFactory interface for creating BFF clients
+type BFFClientFactory interface {
+	// CreateClient creates a client for the specified target BFF
+	CreateClient(target BFFTarget, authToken string) BFFClientInterface
+
+	// CreateClientWithHeaders creates a client with custom headers for the specified target BFF
+	CreateClientWithHeaders(target BFFTarget, authToken string, headers map[string]string) BFFClientInterface
+
+	// GetConfig returns the configuration for a specific target
+	GetConfig(target BFFTarget) *BFFServiceConfig
+
+	// IsTargetConfigured checks if a target BFF is configured
+	IsTargetConfigured(target BFFTarget) bool
+}
+
+// RealClientFactory creates real BFF clients with HTTP communication
+type RealClientFactory struct {
+	config             *BFFClientConfig
+	rootCAs            *x509.CertPool
+	insecureSkipVerify bool
+	logger             *slog.Logger
+}
+
+// NewRealClientFactory creates a factory for real BFF clients
+func NewRealClientFactory(config *BFFClientConfig, rootCAs *x509.CertPool, insecureSkipVerify bool, logger *slog.Logger) BFFClientFactory {
+	return &RealClientFactory{
+		config:             config,
+		rootCAs:            rootCAs,
+		insecureSkipVerify: insecureSkipVerify,
+		logger:             logger,
+	}
+}
+
+// CreateClient creates a new real BFF client for the specified target
+func (f *RealClientFactory) CreateClient(target BFFTarget, authToken string) BFFClientInterface {
+	return f.CreateClientWithHeaders(target, authToken, nil)
+}
+
+// CreateClientWithHeaders creates a new real BFF client with custom headers
+func (f *RealClientFactory) CreateClientWithHeaders(target BFFTarget, authToken string, headers map[string]string) BFFClientInterface {
+	serviceConfig := f.config.GetServiceConfig(target)
+	if serviceConfig == nil {
+		f.logger.Warn("No configuration found for target BFF", "target", target)
+		return nil
+	}
+
+	baseURL := serviceConfig.GetURL(f.config.PodNamespace)
+	f.logger.Debug("Creating BFF client",
+		"target", target,
+		"baseURL", baseURL,
+		"authMethod", serviceConfig.AuthMethod,
+		"authTokenHeader", serviceConfig.AuthTokenHeader,
+		"hasAuthToken", authToken != "",
+		"hasHeaders", len(headers) > 0)
+
+	// Pass auth configuration from service config to the client
+	return NewHTTPBFFClientWithConfig(
+		baseURL,
+		target,
+		authToken,
+		headers,
+		serviceConfig.AuthTokenHeader,
+		serviceConfig.AuthTokenPrefix,
+		f.insecureSkipVerify,
+		f.rootCAs,
+	)
+}
+
+// GetConfig returns the configuration for a specific target
+func (f *RealClientFactory) GetConfig(target BFFTarget) *BFFServiceConfig {
+	return f.config.GetServiceConfig(target)
+}
+
+// IsTargetConfigured checks if a target BFF is configured
+func (f *RealClientFactory) IsTargetConfigured(target BFFTarget) bool {
+	return f.config.GetServiceConfig(target) != nil
+}

--- a/mod-arch-starter/bff/internal/integrations/bffclient/factory_test.go
+++ b/mod-arch-starter/bff/internal/integrations/bffclient/factory_test.go
@@ -1,0 +1,85 @@
+package bffclient
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRealClientFactory_CreateClient(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	config := NewDefaultBFFClientConfig()
+	config.PodNamespace = "test-ns"
+
+	factory := NewRealClientFactory(config, nil, false, logger)
+
+	t.Run("configured target", func(t *testing.T) {
+		client := factory.CreateClient(BFFTargetMaaS, "test-token")
+		require.NotNil(t, client)
+		assert.Equal(t, BFFTargetMaaS, client.GetTarget())
+		assert.Contains(t, client.GetBaseURL(), "test-ns")
+		assert.Contains(t, client.GetBaseURL(), "8243")
+	})
+
+	t.Run("unconfigured target", func(t *testing.T) {
+		// Remove a target from config
+		delete(config.ServiceConfigs, BFFTarget("unknown"))
+		client := factory.CreateClient(BFFTarget("unknown"), "token")
+		assert.Nil(t, client)
+	})
+}
+
+func TestRealClientFactory_CreateClientWithHeaders(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	config := NewDefaultBFFClientConfig()
+	config.PodNamespace = "test-ns"
+
+	factory := NewRealClientFactory(config, nil, false, logger)
+	headers := map[string]string{"kubeflow-userid": "user@test.com"}
+	client := factory.CreateClientWithHeaders(BFFTargetMaaS, "token", headers)
+
+	require.NotNil(t, client)
+	assert.Equal(t, BFFTargetMaaS, client.GetTarget())
+}
+
+func TestRealClientFactory_GetConfig(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	config := NewDefaultBFFClientConfig()
+	factory := NewRealClientFactory(config, nil, false, logger)
+
+	t.Run("existing target", func(t *testing.T) {
+		cfg := factory.GetConfig(BFFTargetMaaS)
+		require.NotNil(t, cfg)
+		assert.Equal(t, BFFTargetMaaS, cfg.Target)
+	})
+
+	t.Run("non-existing target", func(t *testing.T) {
+		cfg := factory.GetConfig(BFFTarget("unknown"))
+		assert.Nil(t, cfg)
+	})
+}
+
+func TestRealClientFactory_IsTargetConfigured(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	config := NewDefaultBFFClientConfig()
+	factory := NewRealClientFactory(config, nil, false, logger)
+
+	assert.True(t, factory.IsTargetConfigured(BFFTargetMaaS))
+	assert.True(t, factory.IsTargetConfigured(BFFTargetGenAI))
+	assert.False(t, factory.IsTargetConfigured(BFFTarget("unknown")))
+}
+
+func TestRealClientFactory_DevOverrideURL(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	config := NewDefaultBFFClientConfig()
+	config.GetServiceConfig(BFFTargetMaaS).DevOverrideURL = "http://localhost:4000/api/v1"
+
+	factory := NewRealClientFactory(config, nil, false, logger)
+	client := factory.CreateClient(BFFTargetMaaS, "token")
+
+	require.NotNil(t, client)
+	assert.Equal(t, "http://localhost:4000/api/v1", client.GetBaseURL())
+}

--- a/mod-arch-starter/bff/internal/integrations/bffclient/middleware.go
+++ b/mod-arch-starter/bff/internal/integrations/bffclient/middleware.go
@@ -1,0 +1,121 @@
+package bffclient
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opendatahub-io/mod-arch-library/bff/internal/constants"
+	helper "github.com/opendatahub-io/mod-arch-library/bff/internal/helpers"
+	k8s "github.com/opendatahub-io/mod-arch-library/bff/internal/integrations/kubernetes"
+)
+
+// GetClient retrieves a BFF client from the context for the specified target
+func GetClient(ctx context.Context, target BFFTarget) BFFClientInterface {
+	key := constants.BFFClientKey(constants.BFFTarget(target))
+	if client, ok := ctx.Value(key).(BFFClientInterface); ok {
+		return client
+	}
+	return nil
+}
+
+// AttachBFFClient creates middleware that attaches a BFF client to the request context.
+// This middleware extracts the user's auth token from RequestIdentity and creates a
+// BFF client configured to forward that token to the target BFF.
+//
+// Usage:
+//
+//	router.GET("/api/v1/some-endpoint",
+//	    app.InjectRequestIdentity(
+//	        bffclient.AttachBFFClient(app.bffFactory, bffclient.BFFTargetMaaS)(
+//	            app.handleSomeEndpoint,
+//	        ),
+//	    ),
+//	)
+func AttachBFFClient(factory BFFClientFactory, target BFFTarget) func(next httprouter.Handle) httprouter.Handle {
+	return func(next httprouter.Handle) httprouter.Handle {
+		return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+			ctx := r.Context()
+			logger := helper.GetContextLoggerFromReq(r)
+
+			// Check if target is configured
+			if !factory.IsTargetConfigured(target) {
+				logger.Debug("Target BFF not configured, attaching nil client", "target", target)
+				ctx = context.WithValue(ctx, constants.BFFClientKey(constants.BFFTarget(target)), nil)
+				next(w, r.WithContext(ctx), ps)
+				return
+			}
+
+			// Get auth token from RequestIdentity
+			var authToken string
+			if identity, ok := ctx.Value(constants.RequestIdentityKey).(*k8s.RequestIdentity); ok && identity != nil {
+				authToken = identity.Token
+			}
+
+			// Create BFF client for target
+			client := factory.CreateClient(target, authToken)
+			if client == nil {
+				logger.Warn("Failed to create BFF client", "target", target)
+				ctx = context.WithValue(ctx, constants.BFFClientKey(constants.BFFTarget(target)), nil)
+				next(w, r.WithContext(ctx), ps)
+				return
+			}
+
+			// Check availability (best effort - log but continue)
+			if !client.IsAvailable(ctx) {
+				logger.Warn("Target BFF unavailable (will continue anyway)", "target", target)
+			} else {
+				logger.Debug("Target BFF available", "target", target, "baseURL", client.GetBaseURL())
+			}
+
+			// Attach to context
+			ctx = context.WithValue(ctx, constants.BFFClientKey(constants.BFFTarget(target)), client)
+			next(w, r.WithContext(ctx), ps)
+		}
+	}
+}
+
+// AttachBFFClientFunc is a convenience wrapper that can be used with standard http.HandlerFunc
+// instead of httprouter.Handle
+func AttachBFFClientFunc(factory BFFClientFactory, target BFFTarget) func(next http.HandlerFunc) http.HandlerFunc {
+	return func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			logger := helper.GetContextLoggerFromReq(r)
+
+			// Check if target is configured
+			if !factory.IsTargetConfigured(target) {
+				logger.Debug("Target BFF not configured, attaching nil client", "target", target)
+				ctx = context.WithValue(ctx, constants.BFFClientKey(constants.BFFTarget(target)), nil)
+				next(w, r.WithContext(ctx))
+				return
+			}
+
+			// Get auth token from RequestIdentity
+			var authToken string
+			if identity, ok := ctx.Value(constants.RequestIdentityKey).(*k8s.RequestIdentity); ok && identity != nil {
+				authToken = identity.Token
+			}
+
+			// Create BFF client for target
+			client := factory.CreateClient(target, authToken)
+			if client == nil {
+				logger.Warn("Failed to create BFF client", "target", target)
+				ctx = context.WithValue(ctx, constants.BFFClientKey(constants.BFFTarget(target)), nil)
+				next(w, r.WithContext(ctx))
+				return
+			}
+
+			// Check availability (best effort - log but continue)
+			if !client.IsAvailable(ctx) {
+				logger.Warn("Target BFF unavailable (will continue anyway)", "target", target)
+			} else {
+				logger.Debug("Target BFF available", "target", target, "baseURL", client.GetBaseURL())
+			}
+
+			// Attach to context
+			ctx = context.WithValue(ctx, constants.BFFClientKey(constants.BFFTarget(target)), client)
+			next(w, r.WithContext(ctx))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add target-agnostic `bffclient` package providing HTTP client infrastructure for inter-BFF communication in multi-container Kubernetes pod deployments. This is pure scaffolding — teams wire up their own target BFF endpoints on top of this infrastructure.

Jira: [RHOAIENG-45979](https://redhat.atlassian.net/browse/RHOAIENG-45979)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Related Issues

Resolves: [RHOAIENG-45979](https://redhat.atlassian.net/browse/RHOAIENG-45979)

## Changes Made

- **`mod-arch-starter/bff/internal/integrations/bffclient/`** — new self-contained package:
  - `client.go` — HTTP client with TLS, auth forwarding, response parsing
  - `config.go` — service discovery (K8s DNS), URL generation, port assignments for known BFFs (Model Registry :8043, Gen-AI :8143, MaaS :8243, MLflow :8343)
  - `errors.go` — structured error types with 10 error codes
  - `factory.go` — factory pattern for real/mock client creation
  - `middleware.go` — context injection middleware (`AttachBFFClient` for httprouter, `AttachBFFClientFunc` for http.HandlerFunc)
  - `bffmocks/mock_client.go` — thread-safe mock implementation with configurable `CallHandler`
  - Full test coverage: `client_test.go`, `config_test.go`, `errors_test.go`, `factory_test.go`
  - `README.md` — package documentation with usage examples
- **`mod-arch-starter/bff/internal/constants/keys.go`** — added `BFFTarget` type and `BFFClientKey()` for context storage
- **`mod-arch-starter/bff/internal/config/environment.go`** — added `MockBFFClients` field
- **`mod-arch-starter/bff/cmd/main.go`** — added `--mock-bff-clients` CLI flag
- **`mod-arch-starter/bff/internal/api/app.go`** — BFF factory initialization with instructional comments showing how to add target-specific config and routes
- **`mod-arch-starter/bff/internal/api/public_helpers.go`** — `BFFClientFactory()` public accessor
- **`mod-arch-starter/bff/README.md`** — inter-BFF communication docs with architecture diagram
- **`mod-arch-installer/flavors/default/bff/`** — matching updates to `main.go` and `environment.go`

## Testing

### How to Test

1. Clone the branch and `cd mod-arch-starter/bff`
2. Run `go build ./...` — should compile cleanly
3. Run `go test ./internal/integrations/bffclient/... -v` — all tests should pass
4. Run `go test ./... -count=1` — full test suite should pass
5. Verify no MaaS-specific references: `grep -r "BFFMaaS\|bff-maas\|BFF_MAAS" --include="*.go"` should return nothing

### Test Results

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Build succeeds (`go build ./...`)
- [x] Installer build succeeds (`npm run build` in mod-arch-installer)
- [x] No MaaS-specific references remain — implementation is fully target-agnostic

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes are backwards compatible (or breaking changes are documented)

## Additional Notes

This implementation is intentionally target-agnostic. It provides the scaffolding for inter-BFF HTTP communication — any team can implement their own target BFF on top of this by following the "Adding a BFF target" guide in the README. The `app.go` file includes instructional comments showing exactly where to apply target-specific config overrides and wire routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added configuration option (`-mock-bff-clients` / `MOCK_BFF_CLIENTS`) to enable mock mode for BFF inter-service communication
  * Implemented inter-BFF communication support for multi-service deployments (Model Registry, Gen-AI, MaaS, MLflow)

* **Documentation**
  * Added comprehensive guide for configuring and using inter-BFF communication
  * Included architecture diagrams and step-by-step integration procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->