### PR TITLE
fix: publish workspaces individually instead of batched

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -32,7 +32,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "node scripts/release-set-version.mjs ${nextRelease.version}",
-        "publishCmd": "npm publish --workspaces --provenance --access public"
+        "publishCmd": "npm publish -w mod-arch-core --provenance --access public && npm publish -w mod-arch-kubeflow --provenance --access public && npm publish -w mod-arch-shared --provenance --access public && npm publish -w mod-arch-installer --provenance --access public"
       }
     ],
     [


### PR DESCRIPTION
## Summary

Fix the release pipeline that has been failing to publish `mod-arch-shared` and `mod-arch-installer` since April 2026. The root cause is that `npm publish --workspaces --provenance` with a granular access token consistently fails with E401 on the 3rd workspace package. Publishing each workspace individually avoids this batch auth/provenance issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI/CD or tooling changes

## Related Issues

Resolves: [RHOAIENG-58158](https://redhat.atlassian.net/browse/RHOAIENG-58158)

## Changes Made

- Changed `publishCmd` in `.releaserc.json` from `npm publish --workspaces --provenance --access public` to individual per-workspace publish commands (`npm publish -w <pkg> --provenance --access public` chained with `&&`)

## Testing

### How to Test

1. Merge this PR — the `fix:` commit will trigger a patch release via semantic-release
2. Verify the release workflow publishes all 4 packages (`mod-arch-core`, `mod-arch-kubeflow`, `mod-arch-shared`, `mod-arch-installer`) successfully to npm at the same version
3. Check https://www.npmjs.com/package/mod-arch-shared to confirm it advances past 1.12.1

### Test Results

- [x] Unit tests pass (`npm test`)
- [x] Lint checks pass (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes are backwards compatible (or breaking changes are documented)

## Additional Notes

**Root cause:** `npm publish --workspaces --provenance` with a granular access token fails on the 3rd workspace with `401 Unauthorized - Failed to generate Web Auth URLs due to error: BadRequestError: token is invalid`. The provenance attestation is signed to Sigstore before the PUT, but the npm registry rejects the upload. This was confirmed in [run 24410236578](https://github.com/opendatahub-io/mod-arch-library/actions/runs/24410236578) (after #199 removed prepublishOnly) — same E401 in under 8 seconds, proving it's the `--workspaces` batch mode, not lifecycle scripts.

**Impact:** `mod-arch-shared` and `mod-arch-installer` have been stuck at 1.12.1 since Apr 2, while `mod-arch-core` and `mod-arch-kubeflow` advanced to 1.15.1.

**Fix:** Publish each workspace individually (`npm publish -w <pkg>`) so each publish is an independent auth+provenance operation.