### PR TITLE
fix: resolve unresolved ~/ path aliases in published packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,43 +39,56 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm run test
-
       - name: Build packages
         run: npm run build
+
+      - name: Verify dist output
+        run: node scripts/verify-dist.mjs
+
+      - name: Run tests
+        run: npm run test
 
       - name: Set package versions
         env:
           VERSION: ${{ github.event.inputs.version }}
-        run: npm version "$VERSION" --no-git-tag-version && npm version "$VERSION" --workspaces --no-git-tag-version
+        run: node scripts/release-set-version.mjs "$VERSION"
+
+      - name: Rebuild after version bump
+        run: npm run build
+
+      - name: Verify dist output after rebuild
+        run: node scripts/verify-dist.mjs
 
       - name: Publish all packages
         if: github.event.inputs.package == 'all'
-        run: npm run publish:all
+        run: |
+          npm publish -w mod-arch-core --provenance --access public --ignore-scripts
+          npm publish -w mod-arch-kubeflow --provenance --access public --ignore-scripts
+          npm publish -w mod-arch-shared --provenance --access public --ignore-scripts
+          npm publish -w mod-arch-installer --provenance --access public --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish core package
         if: github.event.inputs.package == 'core'
-        run: npm run publish:core
+        run: npm publish -w mod-arch-core --provenance --access public --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish shared package
         if: github.event.inputs.package == 'shared'
-        run: npm run publish:shared
+        run: npm publish -w mod-arch-shared --provenance --access public --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish kubeflow package
         if: github.event.inputs.package == 'kubeflow'
-        run: npm run publish:kubeflow
+        run: npm publish -w mod-arch-kubeflow --provenance --access public --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish installer package
         if: github.event.inputs.package == 'installer'
-        run: npm run publish:installer
+        run: npm publish -w mod-arch-installer --provenance --access public --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build packages
         run: npm run build
 
+      - name: Verify dist output
+        run: node scripts/verify-dist.mjs
+
       - name: Run tests
         run: npm run test
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -31,8 +31,8 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "node scripts/release-set-version.mjs ${nextRelease.version}",
-        "publishCmd": "npm publish -w mod-arch-core --provenance --access public && npm publish -w mod-arch-kubeflow --provenance --access public && npm publish -w mod-arch-shared --provenance --access public && npm publish -w mod-arch-installer --provenance --access public"
+        "prepareCmd": "node scripts/release-set-version.mjs ${nextRelease.version} && npm run build && node scripts/verify-dist.mjs",
+        "publishCmd": "npm publish -w mod-arch-core --provenance --access public --ignore-scripts && npm publish -w mod-arch-kubeflow --provenance --access public --ignore-scripts && npm publish -w mod-arch-shared --provenance --access public --ignore-scripts && npm publish -w mod-arch-installer --provenance --access public --ignore-scripts"
       }
     ],
     [

--- a/mod-arch-core/package.json
+++ b/mod-arch-core/package.json
@@ -18,7 +18,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && tsc-alias",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "run-s test:lint test:unit test:type-check",
     "test:jest": "jest",
     "test:unit": "npm run test:jest -- --silent",

--- a/mod-arch-core/tsconfig.build.json
+++ b/mod-arch-core/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "public-cypress",
+    "src/__tests__/cypress",
+    "**/__tests__",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "jest.config.js",
+    "config"
+  ]
+}

--- a/mod-arch-kubeflow/package.json
+++ b/mod-arch-kubeflow/package.json
@@ -19,7 +19,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && tsc-alias && npm run copy-assets",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && npm run copy-assets && tsc-alias -p tsconfig.build.json",
     "copy-assets": "mkdir -p dist/style dist/images && cp -r style/* dist/style/ && cp -r images/* dist/images/",
     "generate-mui-theme-object": "node scripts/generate-mui-theme.mjs",
     "test": "run-s test:lint test:unit test:type-check",

--- a/mod-arch-kubeflow/tsconfig.build.json
+++ b/mod-arch-kubeflow/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "public-cypress",
+    "src/__tests__/cypress",
+    "**/__tests__",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "jest.config.js",
+    "config"
+  ]
+}

--- a/mod-arch-shared/package.json
+++ b/mod-arch-shared/package.json
@@ -18,7 +18,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && tsc-alias && npm run copy-assets",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && npm run copy-assets && tsc-alias -p tsconfig.build.json",
     "copy-assets": "mkdir -p dist/images && cp -r images/* dist/images/ && find components \\( -name '*.scss' -o -name '*.css' \\) -exec rsync -R {} dist/ \\;",
     "test": "run-s test:lint test:unit test:type-check",
     "test:jest": "jest --passWithNoTests",

--- a/mod-arch-shared/tsconfig.build.json
+++ b/mod-arch-shared/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "public-cypress",
+    "src/__tests__/cypress",
+    "**/__tests__",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "jest.config.js",
+    "config"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "version:minor": "npm version minor --no-git-tag-version && npm version minor --workspaces --no-git-tag-version && npm run version:commit",
     "version:major": "npm version major --no-git-tag-version && npm version major --workspaces --no-git-tag-version && npm run version:commit",
     "version:commit": "git add -A && git commit -m \"chore: version bump\" --allow-empty",
-    "publish:all": "npm run build && npm publish --workspaces",
-    "publish:core": "npm run build:core && npm publish --workspace=mod-arch-core",
-    "publish:shared": "npm run build:shared && npm publish --workspace=mod-arch-shared",
-    "publish:kubeflow": "npm run build:kubeflow && npm publish --workspace=mod-arch-kubeflow",
-    "publish:installer": "npm run build:installer && npm publish --workspace=mod-arch-installer",
-    "prepublish:all": "npm run test",
+    "verify-dist": "node scripts/verify-dist.mjs",
+    "publish:all": "npm publish -w mod-arch-core --access public --ignore-scripts && npm publish -w mod-arch-kubeflow --access public --ignore-scripts && npm publish -w mod-arch-shared --access public --ignore-scripts && npm publish -w mod-arch-installer --access public --ignore-scripts",
+    "publish:core": "npm publish -w mod-arch-core --access public --ignore-scripts",
+    "publish:shared": "npm publish -w mod-arch-shared --access public --ignore-scripts",
+    "publish:kubeflow": "npm publish -w mod-arch-kubeflow --access public --ignore-scripts",
+    "publish:installer": "npm publish -w mod-arch-installer --access public --ignore-scripts",
     "prepare": "husky"
   },
   "repository": {

--- a/scripts/verify-dist.mjs
+++ b/scripts/verify-dist.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Pre-publish verification: checks that dist/ output is clean before publishing.
+ *
+ * Catches two classes of problems:
+ *  1. Unresolved ~/xxx path aliases that tsc-alias failed to convert
+ *  2. Test/config files that leaked into dist/ (should be excluded by tsconfig.build.json)
+ *
+ * Usage: node scripts/verify-dist.mjs
+ * Exit code 0 = clean, 1 = problems found
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+
+const rootPkg = JSON.parse(
+  fs.readFileSync(path.join(rootDir, "package.json"), "utf8"),
+);
+const workspaces = rootPkg.workspaces;
+
+// Regex matching unresolved ~/ imports:
+//   import ... from '~/...'
+//   import '~/...'
+//   require('~/...')
+//   export ... from '~/...'
+const unresolvedAliasRe = /(?:from\s+|import\s+|require\(\s*|export\s+.*from\s+)['"]~\//;
+
+// Files/dirs that should NOT exist inside dist/
+const forbiddenInDist = ["__tests__", "jest.config.js", "jest.config.d.ts"];
+
+let hasErrors = false;
+
+function error(msg) {
+  console.error(`  ERROR: ${msg}`);
+  hasErrors = true;
+}
+
+function walkFiles(dir, extensions) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkFiles(fullPath, extensions));
+    } else if (extensions.some((ext) => entry.name.endsWith(ext))) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+for (const ws of workspaces) {
+  const distDir = path.join(rootDir, ws, "dist");
+  if (!fs.existsSync(distDir)) {
+    console.log(`[${ws}] dist/ not found — skipping`);
+    continue;
+  }
+
+  console.log(`[${ws}] Checking dist/...`);
+
+  // Check 1: unresolved ~/ aliases in .js and .d.ts files
+  const sourceFiles = walkFiles(distDir, [".js", ".d.ts"]);
+  for (const filePath of sourceFiles) {
+    const content = fs.readFileSync(filePath, "utf8");
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (unresolvedAliasRe.test(lines[i])) {
+        const relPath = path.relative(rootDir, filePath);
+        error(`${relPath}:${i + 1} — unresolved ~/ alias: ${lines[i].trim()}`);
+      }
+    }
+  }
+
+  // Check 2: forbidden files/dirs in dist/
+  for (const forbidden of forbiddenInDist) {
+    const check = path.join(distDir, forbidden);
+    if (fs.existsSync(check)) {
+      const relPath = path.relative(rootDir, check);
+      error(`${relPath} — test/config file leaked into dist/`);
+    }
+    // Also check recursively for __tests__ dirs
+    if (forbidden === "__tests__") {
+      for (const filePath of sourceFiles) {
+        if (filePath.includes(`${path.sep}__tests__${path.sep}`)) {
+          const relPath = path.relative(rootDir, filePath);
+          error(`${relPath} — test file leaked into dist/`);
+          break; // one error per workspace is enough
+        }
+      }
+    }
+  }
+}
+
+if (hasErrors) {
+  console.error("\nDist verification FAILED — fix the issues above before publishing.");
+  process.exit(1);
+} else {
+  console.log("\nDist verification passed.");
+}


### PR DESCRIPTION
## Summary

Published npm packages (v1.15.3) contain unresolved `~/` path aliases in compiled JS/TS files, forcing downstream consumers to add manual webpack aliases. This PR fixes the root cause and hardens the publish pipeline.

**Root cause**: The build scripts had the wrong step order — `tsc → tsc-alias → copy-assets`. `tsc-alias` checks whether target files exist in `dist/` before resolving path aliases, but non-JS assets (SVG, SCSS, CSS) weren't copied yet. This bug existed since day one but was masked by the `prepare` hook's accidental double-build during `npm publish` (removed in #199).

**Changes**:
- Reorder build to `tsc → copy-assets → tsc-alias` (the core fix)
- Add `tsconfig.build.json` per workspace to exclude test files from `dist/`
- Add `scripts/verify-dist.mjs` as pre-publish safety net (fails on unresolved `~/` paths or leaked test files)
- Add `--ignore-scripts` to all publish commands in CI and root scripts
- Add dist verification steps to `release.yml` and `publish.yml` workflows
- Fix build/test ordering in `publish.yml` (build before test)

Relates-to: [RHOAIENG-58688](https://issues.redhat.com/browse/RHOAIENG-58688)

## Test plan

- [x] `npm run build` succeeds — all `~/` paths resolved to relative paths
- [x] `node scripts/verify-dist.mjs` passes
- [x] No test files (`__tests__/`, `jest.config.*`) in any `dist/` directory
- [x] `tsc --noEmit` still type-checks test files (using default tsconfig.json)
- [x] `npm run test` passes across all workspaces (63 core + 26 shared tests)
- [ ] Semantic-release dry run confirms correct publish behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added verification checks for distribution artifacts to ensure release quality before publishing
  * Enhanced build process with clean builds and improved configuration management
  * Updated release workflow and CI/CD automation for more reliable and consistent deployments
  * Added build-specific TypeScript configurations to improve compilation isolation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->