### PR TITLE
ci: migrate npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,30 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@^11.5.1
+
+      - name: Verify toolchain versions
+        run: |
+          echo "Node $(node -v)"
+          echo "npm $(npm -v)"
+          node -e "
+            const [major, minor, patch] = process.versions.node.split('.').map(Number);
+            if (major < 22 || (major === 22 && minor < 14)) {
+              console.error('Node.js >= 22.14.0 required for OIDC trusted publishing');
+              process.exit(1);
+            }
+          "
+          node -e "
+            const { execSync } = require('child_process');
+            const ver = execSync('npm -v').toString().trim().split('.').map(Number);
+            if (ver[0] < 11 || (ver[0] === 11 && ver[1] < 5) || (ver[0] === 11 && ver[1] === 5 && ver[2] < 1)) {
+              console.error('npm >= 11.5.1 required for OIDC trusted publishing');
+              process.exit(1);
+            }
+          "
 
       - name: Install dependencies
         run: npm ci
@@ -43,5 +65,3 @@ jobs:
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,19 +15,19 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@^11.5.1
+        run: npm install -g npm@11.5.1
 
       - name: Verify toolchain versions
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -4,8 +4,8 @@ package-lock=true
 fund=false
 audit-level=moderate
 
-# Registry configuration (uncomment when ready to publish)
-# registry=https://registry.npmjs.org/
+# Registry configuration
+registry=https://registry.npmjs.org/
 
 # Access level for scoped packages
 access=public

--- a/mod-arch-installer/package.json
+++ b/mod-arch-installer/package.json
@@ -36,9 +36,13 @@
     "typescript": "^5.8.2"
   },
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/opendatahub-io/mod-arch-library.git"
+    "url": "git+https://github.com/opendatahub-io/mod-arch-library.git",
+    "directory": "mod-arch-installer"
   },
   "bugs": {
     "url": "https://github.com/opendatahub-io/mod-arch-library/issues"


### PR DESCRIPTION
## Summary

Migrate npm publishing from long-lived `NPM_TOKEN` to OIDC Trusted Publishing. This eliminates manual token rotation (previously every 90 days) by using short-lived, workflow-scoped credentials from GitHub Actions' OIDC provider.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] CI/CD or tooling changes

## Related Issues

Resolves: [RHOAIENG-58159](https://redhat.atlassian.net/browse/RHOAIENG-58159)

## Changes Made

- **`.github/workflows/release.yml`**:
  - Removed `NPM_TOKEN` and `NODE_AUTH_TOKEN` environment variables from the Semantic Release step
  - Added npm upgrade step (`npm install -g npm@11.5.1`) required for OIDC support
  - Added toolchain version verification step (Node >= 22.14.0, npm >= 11.5.1)
  - Removed `cache: 'npm'` per [npm docs recommendation](https://docs.npmjs.com/trusted-publishers#github-actions-configuration) to avoid caching in release builds
  - Pinned `actions/checkout` and `actions/setup-node` to immutable commit SHAs instead of mutable `v4` tags to prevent supply-chain attacks
  - Pinned npm to exact `11.5.1` instead of `^11.5.1` range to ensure the release auth path uses a fixed, reviewed tool version
- **`.npmrc`**: Uncommented `registry=https://registry.npmjs.org/` to make registry explicit
- **`mod-arch-installer/package.json`**: Added `publishConfig` with `access: "public"` (was missing, unlike other 3 packages) and `directory` field in `repository` for consistency

## Testing

### How to Test

1. **Before merging**, configure OIDC Trusted Publishing on npmjs.com for all 4 packages at their respective `/access` pages (org: `opendatahub-io`, repo: `mod-arch-library`, workflow: `release.yml`)
2. Merge this PR, then trigger a release (`feat:` or `fix:` commit to `main`)
3. Verify all 4 packages publish successfully with provenance attestations on npmjs.com
4. After successful release, remove the `NPM_TOKEN` secret from GitHub repo settings

### Test Results

- [x] Unit tests pass (`npm test`)
- [x] Lint checks pass (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual testing completed (requires npmjs.com trusted publisher config + real release)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes are backwards compatible (or breaking changes are documented)

## Additional Notes

**Manual steps required after merge:**
1. Configure OIDC Trusted Publishing on npmjs.com for `mod-arch-core`, `mod-arch-kubeflow`, `mod-arch-shared`, `mod-arch-installer` — or use `npm trust` CLI (npm >= 11.10.0) for bulk config
2. Verify first OIDC-based release succeeds
3. Delete `NPM_TOKEN` from GitHub repo secrets
4. (Optional) Enable "Require OIDC" on each package's npm settings to fully disable token-based publishing

**References:**
- [npm Trusted Publishing docs](https://docs.npmjs.com/trusted-publishers/)
- [Bulk config announcement](https://github.blog/changelog/2026-02-18-npm-bulk-trusted-publishing-config-and-script-security-now-generally-available/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow with automated toolchain version verification to ensure compatible build environments.
  * Updated NPM registry configuration for package publishing.
  * Configured package for public access on NPM registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->