### PR TITLE
feat: add XKS deployment mode

### DIFF
--- a/mod-arch-core/utilities/const.ts
+++ b/mod-arch-core/utilities/const.ts
@@ -2,6 +2,7 @@ export enum DeploymentMode {
   Standalone = 'standalone',
   Federated = 'federated',
   Kubeflow = 'kubeflow',
+  XKS = 'xks',
 }
 
 const POLL_INTERVAL = 30000;


### PR DESCRIPTION
## Summary
- Adds `XKS = 'xks'` to the `DeploymentMode` enum in `mod-arch-core/utilities/const.ts`
- Supports XKS as a deployment mode so that consumers (e.g., the `distributions/rhaii` layer in odh-dashboard) can select it and wire up platform-specific behavior

**_Note_**: XKS intentionally a no-op — existing code gates on `=== DeploymentMode.Kubeflow`, so XKS falls through to the non-Kubeflow path (no script loading, no central dashboard namespace integration, standard namespace listing), which is correct behavior for a vanilla Kubernetes target


## Context
- `DeploymentMode` is the shared contract that tells consumers which platform they're running on
- XKS (non-OpenShift Kubernetes) needs its own mode distinct from `Standalone` and `Federated`, which both assume OpenShift
- The behavioral differences will live in the platform provider layer in the consuming app, not in mod-arch-library itself — the mode is the *selector*, the platform provider is the *implementation*

## Test plan
- [x] `npm run build:core` — passes
- [x] `npm run test:core` — all 65 tests pass
- [x] Verified no existing code branches on an exhaustive `DeploymentMode` match — all checks are `=== Kubeflow` guards, so the new value is safely inert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added XKS as a new supported deployment mode option, expanding your deployment configuration choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->