### PR TITLE
chore: add andyatmiami and jenny-s51 to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -17,6 +17,8 @@ approvers:
   - adnankhan666
   - bobbravo2
   - jessiehuff
+  - andyatmiami
+  - jenny-s51
 reviewers:
   - lucferbux
   - christianvogt


### PR DESCRIPTION
## Summary
- Adds `andyatmiami` and `jenny-s51` to the approvers list in OWNERS

🤖 Generated with [Claude Code](https://claude.com/claude-code)