### PR TITLE
feat(shared): add descriptionTextNode prop to ThemeAwareFormGroupWrapper

### DIFF
--- a/mod-arch-shared/components/ThemeAwareFormGroupWrapper.tsx
+++ b/mod-arch-shared/components/ThemeAwareFormGroupWrapper.tsx
@@ -8,6 +8,8 @@ type ThemeAwareFormGroupWrapperProps = {
   label?: string;
   fieldId: string;
   isRequired?: boolean;
+  /** Always-visible description text rendered outside the fieldset (MUI) or before children (PF) */
+  descriptionTextNode?: React.ReactNode;
   helperTextNode?: React.ReactNode;
   hasError?: boolean;
   className?: string;
@@ -24,6 +26,7 @@ const ThemeAwareFormGroupWrapper: React.FC<ThemeAwareFormGroupWrapperProps> = ({
   label,
   fieldId,
   isRequired,
+  descriptionTextNode,
   helperTextNode,
   hasError = false,
   className,
@@ -51,6 +54,7 @@ const ThemeAwareFormGroupWrapper: React.FC<ThemeAwareFormGroupWrapperProps> = ({
   if (isMUITheme) {
     return (
       <>
+        {descriptionTextNode}
         <FormGroup {...formGroupProps}>
           {skipFieldset ? children : <FormFieldset component={children} field={label} />}
         </FormGroup>
@@ -62,6 +66,7 @@ const ThemeAwareFormGroupWrapper: React.FC<ThemeAwareFormGroupWrapperProps> = ({
   return (
     <>
       <FormGroup {...formGroupProps}>
+        {descriptionTextNode}
         {children}
         {helperTextNode}
       </FormGroup>


### PR DESCRIPTION
## Summary

- Add an optional `descriptionTextNode` prop to `ThemeAwareFormGroupWrapper` for always-visible description text
- **PF theme:** renders inside `FormGroup`, before children
- **MUI theme:** renders before `FormGroup`, outside the fieldset

## Motivation

Consumers that need description text alongside form inputs (e.g. `CredentialsSection`, `ModelVisibilitySection` in [kubeflow/hub](https://github.com/kubeflow/hub)) currently pass it as `children`. On MUI theme, this causes the description to be wrapped inside `FormFieldset` — appearing within the input field border instead of above it.

This was reported in https://github.com/kubeflow/hub/pull/2719#discussion_r2158367226

The original local `ThemeAwareFormGroupWrapper` in kubeflow/hub had this prop; it was lost when migrating to the shared component.

## Test plan

- [x] ESLint passes (lint-staged hook)
- [ ] Verify MUI theme renders description above the fieldset
- [ ] Verify PF theme renders description inside FormGroup before input
- [ ] Existing consumers unaffected (prop is optional, defaults to `undefined`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form groups can now display optional description text above the form content, improving clarity in form layouts across different themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->