### PR TITLE
feat(shared): add tooltipPosition prop to TruncatedText component

### DIFF
--- a/mod-arch-shared/components/TruncatedText.tsx
+++ b/mod-arch-shared/components/TruncatedText.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
-import { Tooltip } from '@patternfly/react-core';
+import { Tooltip, type TooltipProps } from '@patternfly/react-core';
 
 type TruncatedTextProps = {
   maxLines: number;
   content: React.ReactNode;
+  tooltipPosition?: TooltipProps['position'];
 } & Omit<React.HTMLProps<HTMLSpanElement>, 'content'>;
 
-const TruncatedText: React.FC<TruncatedTextProps> = ({ maxLines, content, ...props }) => {
+const TruncatedText: React.FC<TruncatedTextProps> = ({
+  maxLines,
+  content,
+  tooltipPosition,
+  ...props
+}) => {
   const outerElementRef = React.useRef<HTMLElement>(null);
   const textElementRef = React.useRef<HTMLElement>(null);
   const [isTruncated, setIsTruncated] = React.useState<boolean>(false);
@@ -43,7 +49,7 @@ const TruncatedText: React.FC<TruncatedTextProps> = ({ maxLines, content, ...pro
   );
 
   return (
-    <Tooltip hidden={!isTruncated ? true : undefined} content={content}>
+    <Tooltip hidden={!isTruncated ? true : undefined} content={content} position={tooltipPosition}>
       {truncateBody}
     </Tooltip>
   );


### PR DESCRIPTION
## Summary

Add a `tooltipPosition` prop to the `TruncatedText` component, allowing consumers to control the tooltip placement (top, bottom, left, right, auto, etc.) instead of relying on the default auto-positioning.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or tooling changes

## Related Issues

Resolves: [RHOAIENG-56639](https://redhat.atlassian.net/browse/RHOAIENG-56639)

## Changes Made

- Added optional `tooltipPosition` prop to `TruncatedTextProps`, typed as `TooltipProps['position']` from PatternFly
- Passed the prop through to the underlying `<Tooltip>` component
- Fully backwards compatible — when omitted, Tooltip uses its default positioning behavior

## Testing

### How to Test

1. Import `TruncatedText` and pass `tooltipPosition="bottom"` (or any valid position)
2. Verify the tooltip renders in the specified position when text is truncated
3. Verify default behavior is unchanged when `tooltipPosition` is not provided

### Test Results

- [x] Unit tests pass (`npm test`)
- [x] Lint checks pass (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes are backwards compatible (or breaking changes are documented)

## Screenshots / Output

N/A

## Additional Notes

The prop uses PatternFly's `TooltipProps['position']` type directly, ensuring type safety and alignment with PF6 API. This is needed in contexts where auto-positioning causes the tooltip to overflow or appear in undesirable locations (e.g., inside tables or constrained containers).